### PR TITLE
Fix cast exception within SendTags on Android

### DIFF
--- a/OneSignalSDK.dotnet.Android/OneSignalImplementation.cs
+++ b/OneSignalSDK.dotnet.Android/OneSignalImplementation.cs
@@ -182,7 +182,7 @@ namespace OneSignalSDK.DotNet.Android
 
       public override async Task<bool> SendTags(Dictionary<string, object> tags) {
          OSChangeTagsUpdateHandler handler = new OSChangeTagsUpdateHandler();
-         OneSignalNative.SendTags((JSONObject)Json.Serialize(tags), handler);
+         OneSignalNative.SendTags(new JSONObject(Json.Serialize(tags)), handler);
          return await handler;
       }
 

--- a/Samples/OneSignalApp/exampledotnet/exampledotnet.csproj
+++ b/Samples/OneSignalApp/exampledotnet/exampledotnet.csproj
@@ -27,10 +27,6 @@
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0-ios|AnyCPU'">
 	  <CreatePackage>false</CreatePackage>
 	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-	  <DefineConstants>TRACE;DEBUG;NET;NET6_0;NETCOREAPP;LIVE_ACTIVITIES</DefineConstants>
-	  <WarningLevel>4</WarningLevel>
-	</PropertyGroup>
 	<ItemGroup>
 		<!-- App Icon -->
 		<MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#512BD4" />


### PR DESCRIPTION
# Description
## One Line Summary
Fix casting exception thrown on Android for `OneSignal.Default.SendTags` call

## Details

### Motivation
Bug fix

# Testing
## Manual testing
Ran sample app on Android with `SendTags` to ensure proper functionality

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.