### PR TITLE
[User Model] Xamarin support

### DIFF
--- a/OneSignalSDK.DotNet.Android.Core.Binding/OneSignalSDK.DotNet.Android.Core.Binding.csproj
+++ b/OneSignalSDK.DotNet.Android.Core.Binding/OneSignalSDK.DotNet.Android.Core.Binding.csproj
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha3">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFrameworks>net6.0-android31;monoandroid12.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/OneSignalSDK.DotNet.Android.InAppMessages.Binding/OneSignalSDK.DotNet.Android.InAppMessages.Binding.csproj
+++ b/OneSignalSDK.DotNet.Android.InAppMessages.Binding/OneSignalSDK.DotNet.Android.InAppMessages.Binding.csproj
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha3">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFrameworks>net6.0-android31;monoandroid12.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/OneSignalSDK.DotNet.Android.Location.Binding/OneSignalSDK.DotNet.Android.Location.Binding.csproj
+++ b/OneSignalSDK.DotNet.Android.Location.Binding/OneSignalSDK.DotNet.Android.Location.Binding.csproj
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha3">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFrameworks>net6.0-android31;monoandroid12.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/OneSignalSDK.DotNet.Android.Notifications.Binding/OneSignalSDK.DotNet.Android.Notifications.Binding.csproj
+++ b/OneSignalSDK.DotNet.Android.Notifications.Binding/OneSignalSDK.DotNet.Android.Notifications.Binding.csproj
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha3">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFrameworks>net6.0-android31;monoandroid12.0</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/OneSignalSDK.DotNet.Android/OneSignalSDK.DotNet.Android.csproj
+++ b/OneSignalSDK.DotNet.Android/OneSignalSDK.DotNet.Android.csproj
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha3">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{FB0C2961-BAFE-4346-B279-3B3941614DCD}</ProjectGuid>
-    <TargetFramework>net6.0-android</TargetFramework>
+    <TargetFrameworks>net6.0-android31;monoandroid12.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
-    <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>OneSignalSDK.DotNet.Android</RootNamespace>
     <AssemblyName>OneSignalSDK.DotNet.Android</AssemblyName>
@@ -37,14 +36,26 @@
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\OneSignalSDK.DotNet.Core\OneSignalSDK.DotNet.Core.csproj" />
-    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Core.Binding\OneSignalSDK.DotNet.Android.Core.Binding.csproj" />
-    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.InAppMessages.Binding\OneSignalSDK.DotNet.Android.InAppMessages.Binding.csproj" />
-    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Location.Binding\OneSignalSDK.DotNet.Android.Location.Binding.csproj" />
-    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Notifications.Binding\OneSignalSDK.DotNet.Android.Notifications.Binding.csproj" />
+    <ProjectReference Include="..\OneSignalSDK.DotNet.Core\OneSignalSDK.DotNet.Core.csproj">
+      <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>
+    </ProjectReference>
+    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Core.Binding\OneSignalSDK.DotNet.Android.Core.Binding.csproj">
+      <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>
+    </ProjectReference>
+    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.InAppMessages.Binding\OneSignalSDK.DotNet.Android.InAppMessages.Binding.csproj">
+      <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>
+    </ProjectReference>
+    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Location.Binding\OneSignalSDK.DotNet.Android.Location.Binding.csproj">
+      <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>
+    </ProjectReference>
+    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Notifications.Binding\OneSignalSDK.DotNet.Android.Notifications.Binding.csproj">
+      <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="1.8.0.1" />
+    <PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.6.4.2" />
+    <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.6.4.2" />
     <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.14" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.4.0.2" />
@@ -55,9 +66,5 @@
     <PackageReference Include="Xamarin.Google.Dagger" Version="2.41.0.2" />
     <PackageReference Include="Xamarin.GooglePlayServices.Base" Version="118.1.0" />
     <PackageReference Include="Xamarin.AndroidX.Work.Work.Runtime.Ktx" Version="2.7.1.5" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove="Xamarin.Kotlin.StdLib.Jdk7" />
-    <None Remove="Xamarin.AndroidX.Work.Work.Runtime.Ktx" />
   </ItemGroup>
 </Project>

--- a/OneSignalSDK.DotNet.Core/OneSignalSDK.DotNet.Core.csproj
+++ b/OneSignalSDK.DotNet.Core/OneSignalSDK.DotNet.Core.csproj
@@ -1,11 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disable</ImplicitUsings>
     <AssemblyName>OneSignalSDK.DotNet.Core</AssemblyName>
     <PackageId>OneSignalSDK.DotNet.Core</PackageId>
   </PropertyGroup>
@@ -24,14 +22,8 @@
     <AllowUnsafeBlocks></AllowUnsafeBlocks>
     <CheckForOverflowUnderflow></CheckForOverflowUnderflow>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-  </ItemGroup>
 
   <ItemGroup>
-    <None Remove="NETStandard.Library" />
-    <None Remove="Microsoft.NETCore.Portable.Compatibility" />
     <None Remove="User\" />
     <None Remove="Session\" />
     <None Remove="Notifications\" />

--- a/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
+++ b/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
@@ -244,10 +244,6 @@ namespace Com.OneSignal.iOS {
         // -(NSDictionary * _Nonnull)jsonRepresentation;
         [Export ("jsonRepresentation")]
         NSDictionary JsonRepresentation { get; }
-
-        // -(instancetype _Nonnull)initWithPermission:(BOOL)permission;
-        [Export ("initWithPermission:")]
-        NativeHandle Constructor(bool permission);
     }
 
 	// @protocol OSPermissionObserver <NSObject>

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha3">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <TargetFramework>net6.0-ios</TargetFramework>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net6.0-ios10.0;xamarin.ios10</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <RootNamespace>OneSignalSDK.DotNet.iOS.Binding</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>OneSignalSDK.DotNet.iOS.Binding</AssemblyName>

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
@@ -7,7 +7,7 @@
     <ImplicitUsings>true</ImplicitUsings>
     <IsBindingProject>true</IsBindingProject>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
     <RootNamespace>OneSignalSDK.DotNet.iOS.Binding</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>OneSignalSDK.DotNet.iOS.Binding</AssemblyName>

--- a/OneSignalSDK.DotNet.iOS/OneSignalSDK.DotNet.iOS.csproj
+++ b/OneSignalSDK.DotNet.iOS/OneSignalSDK.DotNet.iOS.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>net6.0-ios10.0;xamarin.ios10</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>9.0</SupportedOSPlatformVersion>
     <RootNamespace>OneSignalSDK.DotNet.iOS</RootNamespace>
     <AssemblyName>OneSignalSDK.DotNet.iOS</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>

--- a/OneSignalSDK.DotNet.iOS/OneSignalSDK.DotNet.iOS.csproj
+++ b/OneSignalSDK.DotNet.iOS/OneSignalSDK.DotNet.iOS.csproj
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha3">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5FF66A21-BA7B-48FD-8A7D-6A1092066306}</ProjectGuid>
-    <TargetFramework>net6.0-ios</TargetFramework>
-    <Nullable>enable</Nullable>
+    <TargetFrameworks>net6.0-ios10.0;xamarin.ios10</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>10.0</SupportedOSPlatformVersion>
     <RootNamespace>OneSignalSDK.DotNet.iOS</RootNamespace>
     <AssemblyName>OneSignalSDK.DotNet.iOS</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
@@ -38,13 +37,21 @@
     <MtouchLink>SdkOnly</MtouchLink>
     <CreatePackage>false</CreatePackage>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net6.0-ios')) ">
     <Reference Include="Microsoft.iOS" />
+  </ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarin.ios10')) ">
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OneSignalSDK.DotNet.Core\OneSignalSDK.DotNet.Core.csproj">
+      <ReferenceSourceTarget></ReferenceSourceTarget>
     </ProjectReference>
     <ProjectReference Include="..\OneSignalSDK.DotNet.iOS.Binding\OneSignalSDK.DotNet.iOS.Binding.csproj">
+      <ReferenceSourceTarget></ReferenceSourceTarget>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/OneSignalSDK.DotNet.nuspec
+++ b/OneSignalSDK.DotNet.nuspec
@@ -68,7 +68,7 @@
         <file src="OneSignalSDK.DotNet\bin\Release\netstandard2.0\OneSignalSDK.DotNet.pdb" target="lib\netstandard2.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\netstandard2.0\OneSignalSDK.DotNet.Core.pdb" target="lib\netstandard2.0" />
 
-        <!--net6.0-android31-->
+        <!--net6.0-android31 (minimum runtime 5.0/API 21)-->
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.dll" target="lib\net6.0-android31.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Core.dll" target="lib\net6.0-android31.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.dll" target="lib\net6.0-android31.0" />
@@ -90,7 +90,7 @@
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\location-release.aar" target="lib\net6.0-android31.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\notifications-release.aar" target="lib\net6.0-android31.0" />
 
-        <!--monoandroid12.0-->
+        <!--monoandroid12.0 (minimum runtime 5.0/API 21)-->
         <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.dll" target="lib\monoandroid12.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Core.dll" target="lib\monoandroid12.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.dll" target="lib\monoandroid12.0" />
@@ -107,7 +107,7 @@
         <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.Location.Binding.pdb" target="lib\monoandroid12.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.Notifications.Binding.pdb" target="lib\monoandroid12.0" />
 
-        <!--net6.0-ios10.0-->
+        <!--net6.0-ios10.0 (minimum runtime 9.0)-->
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.dll" target="lib\net6.0-ios10.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.Core.dll" target="lib\net6.0-ios10.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.iOS.dll" target="lib\net6.0-ios10.0" />
@@ -118,7 +118,7 @@
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.iOS.pdb" target="lib\net6.0-ios10.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.iOS.Binding.pdb" target="lib\net6.0-ios10.0" />
 
-        <!--xamarin.ios10-->
+        <!--xamarin.ios10 (minimum runtime 9.0)-->
         <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.dll" target="lib\xamarin.ios10" />
         <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.Core.dll" target="lib\xamarin.ios10" />
         <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.iOS.dll" target="lib\xamarin.ios10" />

--- a/OneSignalSDK.DotNet.nuspec
+++ b/OneSignalSDK.DotNet.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
-        <version>5.0.0-beta01</version>
+        <version>5.0.0-beta02</version>
         <id>OneSignalSDK.DotNet</id>
         <title>OneSignal SDK for .Net6+ </title>
         <authors>OneSignal</authors>
@@ -14,12 +14,16 @@
         <summary>OneSignal is a free push notification service for mobile apps. This plugin makes it easy to integrate your .Net6+ app with OneSignal</summary>
         <tags>MAUI, .Net, C#, OneSignal, push</tags>
         <dependencies>
-            <group targetFramework="net6.0">
+            <group targetFramework="netstandard2.0">
             </group>
             <group targetFramework="net6.0-ios10.0">
             </group>
+            <group targetFramework="xamarin.ios10">
+            </group>
             <group targetFramework="net6.0-android21.0">
                 <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.8.0.1" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Core" version="1.6.4.2" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Android" version="1.6.4.2" />
 
                 <dependency id="Xamarin.AndroidX.CardView" version="1.0.0.16" />
                 <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.14" />
@@ -34,58 +38,105 @@
                 <dependency id="Xamarin.Google.Dagger" version="2.41.0.2" />
                 <dependency id="Xamarin.GooglePlayServices.Base" version="118.1.0" />
             </group>
+            <group targetFramework="monoandroid12.0">
+                <dependency id="Xamarin.Kotlin.StdLib.Jdk8" version="1.8.0.1" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Core" version="1.6.4.2" />
+                <dependency id="Xamarin.KotlinX.Coroutines.Android" version="1.6.4.2" />
+
+                <dependency id="Xamarin.AndroidX.CardView" version="1.0.0.11" />
+                <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.10" />
+                <dependency id="Xamarin.AndroidX.Browser" version="1.3.0.8" />
+                <dependency id="Xamarin.AndroidX.AppCompat" version="1.3.1.3" />
+                <dependency id="Xamarin.AndroidX.Work.Runtime" version="2.7.0" />
+                <dependency id="Xamarin.AndroidX.Work.Work.Runtime.Ktx" version="2.7.0" />
+
+                <dependency id="Xamarin.Firebase.Messaging" version="122.0.0.2" />
+                <!-- Dagger is required for FCM, should be a "transitive dependency" but is not due to this bug:
+                     https://github.com/xamarin/XamarinComponents/issues/1069 -->
+                <dependency id="Xamarin.Google.Dagger" version="2.39.1" />
+            </group>
         </dependencies>
     </metadata>
     <files>
         <file src="nuget_icon.png" />
         <file src="LICENSE.md" />
 
-        <!--Core-->
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0\OneSignalSDK.DotNet.dll" target="lib\net6.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0\OneSignalSDK.DotNet.Core.dll" target="lib\net6.0" />
+        <!--netstandard2.0-->
+        <file src="OneSignalSDK.DotNet\bin\Release\netstandard2.0\OneSignalSDK.DotNet.dll" target="lib\netstandard2.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\netstandard2.0\OneSignalSDK.DotNet.Core.dll" target="lib\netstandard2.0" />
 
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0\OneSignalSDK.DotNet.pdb" target="lib\net6.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0\OneSignalSDK.DotNet.Core.pdb" target="lib\net6.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\netstandard2.0\OneSignalSDK.DotNet.pdb" target="lib\netstandard2.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\netstandard2.0\OneSignalSDK.DotNet.Core.pdb" target="lib\netstandard2.0" />
 
-        <!--net6.0-android-->
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.dll" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Core.dll" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.dll" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.Core.Binding.dll" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.InAppMessages.Binding.dll" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.Location.Binding.dll" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.Notifications.Binding.dll" target="lib\net6.0-android21.0" />
+        <!--net6.0-android31-->
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.dll" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Core.dll" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.dll" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.Core.Binding.dll" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.InAppMessages.Binding.dll" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.Location.Binding.dll" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.Notifications.Binding.dll" target="lib\net6.0-android31.0" />
 
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.pdb" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Core.pdb" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.pdb" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.Core.Binding.pdb" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.InAppMessages.Binding.pdb" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.Location.Binding.pdb" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\OneSignalSDK.DotNet.Android.Notifications.Binding.pdb" target="lib\net6.0-android21.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.pdb" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Core.pdb" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.pdb" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.Core.Binding.pdb" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.InAppMessages.Binding.pdb" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.Location.Binding.pdb" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\OneSignalSDK.DotNet.Android.Notifications.Binding.pdb" target="lib\net6.0-android31.0" />
 
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\core-release.aar" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\in-app-messages-release.aar" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\location-release.aar" target="lib\net6.0-android21.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android\notifications-release.aar" target="lib\net6.0-android21.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\core-release.aar" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\in-app-messages-release.aar" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\location-release.aar" target="lib\net6.0-android31.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-android31\notifications-release.aar" target="lib\net6.0-android31.0" />
 
-        <!--net6.0-ios-->
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios\OneSignalSDK.DotNet.dll" target="lib\net6.0-ios10.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios\OneSignalSDK.DotNet.Core.dll" target="lib\net6.0-ios10.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios\OneSignalSDK.DotNet.iOS.dll" target="lib\net6.0-ios10.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios\OneSignalSDK.DotNet.iOS.Binding.dll" target="lib\net6.0-ios10.0" />
+        <!--monoandroid12.0-->
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.dll" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Core.dll" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.dll" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.Core.Binding.dll" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.InAppMessages.Binding.dll" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.Location.Binding.dll" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.Notifications.Binding.dll" target="lib\monoandroid12.0" />
 
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios\OneSignalSDK.DotNet.pdb" target="lib\net6.0-ios10.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios\OneSignalSDK.DotNet.Core.pdb" target="lib\net6.0-ios10.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios\OneSignalSDK.DotNet.iOS.pdb" target="lib\net6.0-ios10.0" />
-        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios\OneSignalSDK.DotNet.iOS.Binding.pdb" target="lib\net6.0-ios10.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.pdb" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Core.pdb" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.pdb" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.Core.Binding.pdb" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.InAppMessages.Binding.pdb" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.Location.Binding.pdb" target="lib\monoandroid12.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\monoandroid12.0\OneSignalSDK.DotNet.Android.Notifications.Binding.pdb" target="lib\monoandroid12.0" />
+
+        <!--net6.0-ios10.0-->
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.dll" target="lib\net6.0-ios10.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.Core.dll" target="lib\net6.0-ios10.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.iOS.dll" target="lib\net6.0-ios10.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.iOS.Binding.dll" target="lib\net6.0-ios10.0" />
+
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.pdb" target="lib\net6.0-ios10.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.Core.pdb" target="lib\net6.0-ios10.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.iOS.pdb" target="lib\net6.0-ios10.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net6.0-ios10.0\OneSignalSDK.DotNet.iOS.Binding.pdb" target="lib\net6.0-ios10.0" />
+
+        <!--xamarin.ios10-->
+        <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.dll" target="lib\xamarin.ios10" />
+        <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.Core.dll" target="lib\xamarin.ios10" />
+        <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.iOS.dll" target="lib\xamarin.ios10" />
+        <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.iOS.Binding.dll" target="lib\xamarin.ios10" />
+
+        <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.pdb" target="lib\xamarin.ios10" />
+        <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.Core.pdb" target="lib\xamarin.ios10" />
+        <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.iOS.pdb" target="lib\xamarin.ios10" />
+        <file src="OneSignalSDK.DotNet\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.iOS.Binding.pdb" target="lib\xamarin.ios10" />
 
         <!-- Workaround to support .XCFramework for iOS  -->
         <!-- Resources includes the full OneSignal.XCFramework.
              iOS.Binding project has NoBindingEmbedding = true so it isn't also bundled in the .dll -->
-        <file src="OneSignalSDK.DotNet.iOS.Binding\bin\Release\net6.0-ios\OneSignalSDK.DotNet.iOS.Binding.resources\**" target="res\ios" />
+        <file src="OneSignalSDK.DotNet.iOS.Binding\bin\Release\xamarin.ios10\OneSignalSDK.DotNet.iOS.Binding.resources\**" target="res\ios" />
+        
         <!-- This is a .target files that gets used by project that consumes the NuGet package.
              This copies out the OneSignal.xcframework from the resources folder and adds a NativeReference to it in the app project. -->
         <file src="OneSignalSDK.DotNet.iOS.Binding\OneSignalSDK.DotNet.targets" target="build\net6.0-ios10.0\" />
+        <file src="OneSignalSDK.DotNet.iOS.Binding\OneSignalSDK.DotNet.targets" target="build\xamarin.ios10\" />
     </files>    
 </package>

--- a/OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj
+++ b/OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha3">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net6.0-ios;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0-ios10.0;xamarin.ios10;net6.0-android31;monoandroid12.0</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disable</ImplicitUsings>
     <AssemblyName>OneSignalSDK.DotNet</AssemblyName>
     <PackageId>OneSignalSDK.DotNet</PackageId>
-    <SupportedOSPlatformVersion Condition=" $(TargetFramework.StartsWith('net6.0-android')) ">21.0</SupportedOSPlatformVersion>
-	<SupportedOSPlatformVersion Condition=" $(TargetFramework.StartsWith('net6.0-ios')) ">10.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition=" $(TargetFramework.StartsWith('net6.0-android')) Or $(TargetFramework.StartsWith('monoandroid')) ">21.0</SupportedOSPlatformVersion>
+	<SupportedOSPlatformVersion Condition=" $(TargetFramework.StartsWith('net6.0-ios')) Or $(TargetFramework.StartsWith('xamarin.ios')) ">10.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -23,12 +23,8 @@
     <CreatePackage>false</CreatePackage>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\OneSignalSDK.DotNet.Core\OneSignalSDK.DotNet.Core.csproj" />
-    <ProjectReference Include="..\OneSignalSDK.DotNet.Android\OneSignalSDK.DotNet.Android.csproj" Condition=" $(TargetFramework.StartsWith('net6.0-android')) " />
-    <ProjectReference Include="..\OneSignalSDK.DotNet.iOS\OneSignalSDK.DotNet.iOS.csproj" Condition=" $(TargetFramework.StartsWith('net6.0-ios')) " />
+    <ProjectReference Include="..\OneSignalSDK.DotNet.Android\OneSignalSDK.DotNet.Android.csproj" Condition=" $(TargetFramework.StartsWith('net6.0-android')) Or $(TargetFramework.StartsWith('monoandroid')) " />
+    <ProjectReference Include="..\OneSignalSDK.DotNet.iOS\OneSignalSDK.DotNet.iOS.csproj" Condition=" $(TargetFramework.StartsWith('net6.0-ios')) Or $(TargetFramework.StartsWith('xamarin.ios')) " />
   </ItemGroup>
 </Project>

--- a/OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj
+++ b/OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>OneSignalSDK.DotNet</AssemblyName>
     <PackageId>OneSignalSDK.DotNet</PackageId>
     <SupportedOSPlatformVersion Condition=" $(TargetFramework.StartsWith('net6.0-android')) Or $(TargetFramework.StartsWith('monoandroid')) ">21.0</SupportedOSPlatformVersion>
-	<SupportedOSPlatformVersion Condition=" $(TargetFramework.StartsWith('net6.0-ios')) Or $(TargetFramework.StartsWith('xamarin.ios')) ">10.0</SupportedOSPlatformVersion>
+	<SupportedOSPlatformVersion Condition=" $(TargetFramework.StartsWith('net6.0-ios')) Or $(TargetFramework.StartsWith('xamarin.ios')) ">9.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Samples/OneSignalApp/OneSignalApp.csproj
+++ b/Samples/OneSignalApp/OneSignalApp.csproj
@@ -53,10 +53,10 @@
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-android'">
 	  <GoogleServicesJson Include="Platforms\Android\google-services.json" />
 	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android\OneSignalSDK.DotNet.Android.csproj" />
-	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android.Binding\OneSignalSDK.DotNet.Android.Core.Binding.csproj" />
-	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android.Binding\OneSignalSDK.DotNet.Android.InAppMessages.Binding.csproj" />
-	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android.Binding\OneSignalSDK.DotNet.Android.Location.Binding.csproj" />
-	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android.Binding\OneSignalSDK.DotNet.Android.Notifications.Binding.csproj" />
+	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android.Core.Binding\OneSignalSDK.DotNet.Android.Core.Binding.csproj" />
+	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android.InAppMessages.Binding\OneSignalSDK.DotNet.Android.InAppMessages.Binding.csproj" />
+	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android.Location.Binding\OneSignalSDK.DotNet.Android.Location.Binding.csproj" />
+	  <ProjectReference Include="..\..\OneSignalSDK.DotNet.Android.Notifications.Binding\OneSignalSDK.DotNet.Android.Notifications.Binding.csproj" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-ios'">


### PR DESCRIPTION
* Update platform-specific libraries to use `Xamarin.Legacy.Sdk`, which allows them to target both .NET and Xamarin platforms.
* Update nuspec to support all 4 platforms.
