### PR TITLE
[User Model] Reimplement live activities

### DIFF
--- a/OneSignalSDK.DotNet.Android/AndroidOneSignal.cs
+++ b/OneSignalSDK.DotNet.Android/AndroidOneSignal.cs
@@ -74,4 +74,16 @@ public class AndroidOneSignal : IOneSignal
     {
         OneSignalNative.Logout();
     }
+
+    public Task<bool> EnterLiveActivityAsync(string activityId, string token)
+    {
+        Console.WriteLine("OneSignal: EnterLiveActivity is available on iOS only");
+        return Task.FromResult(false);
+    }
+
+    public Task<bool> ExitLiveActivityAsync(string activityId)
+    {
+        Console.WriteLine("OneSignal: ExitLiveActivity is available on iOS only");
+        return Task.FromResult(false);
+    }
 }

--- a/OneSignalSDK.DotNet.Core/IOneSignal.cs
+++ b/OneSignalSDK.DotNet.Core/IOneSignal.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using OneSignalSDK.DotNet.Core.Debug;
 using OneSignalSDK.DotNet.Core.InAppMessages;
 using OneSignalSDK.DotNet.Core.Location;
@@ -104,5 +105,23 @@ namespace OneSignalSDK.DotNet.Core
         /// long as the app remains installed and the app data is not cleared.
         /// </summary>
         void Logout();
+
+        #region Live Activities (iOS only)
+        /// <summary>
+        /// Register this device with OneSignal indicating that the device has entered a live activity.
+        /// </summary>
+        /// <param name="activityId">The (app-provided) ID of the activity that is being entered.</param>
+        /// <param name="token">The (OS-provided) token that will be used to update the content-state of the live activity on this device.</param>
+        /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
+        Task<bool> EnterLiveActivityAsync(string activityId, string token);
+
+        /// <summary>
+        /// Unregister this device with OneSignal indicating that the device has exited a live activity.
+        /// </summary>
+        /// <param name="activityId">The (app-provided) ID of the activity that is being exited.</param>
+        /// <returns>Awaitable boolean of whether the operation succeeded or failed</returns>
+        Task<bool> ExitLiveActivityAsync(string activityId);
+
+        #endregion;
     }
 }

--- a/OneSignalSDK.DotNet.iOS/iOSOneSignal.cs
+++ b/OneSignalSDK.DotNet.iOS/iOSOneSignal.cs
@@ -9,6 +9,7 @@ using OneSignalSDK.DotNet.Core.User;
 using OneSignalSDK.DotNet.Core.Internal.Utilities;
 
 using OneSignalNative = Com.OneSignal.iOS.OneSignal;
+using OneSignalSDK.DotNet.iOS.Utilities;
 
 namespace OneSignalSDK.DotNet.iOS;
 
@@ -70,5 +71,19 @@ public class iOSOneSignal : IOneSignal
     public void Logout()
     {
         OneSignalNative.Logout();
+    }
+
+    public async Task<bool> EnterLiveActivityAsync(string activityId, string token)
+    {
+        BooleanCallbackProxy proxy = new BooleanCallbackProxy();
+        OneSignalNative.EnterLiveActivity(activityId, token, response => proxy.OnResponse(true), response => proxy.OnResponse(false));
+        return await proxy;
+    }
+
+    public async Task<bool> ExitLiveActivityAsync(string activityId)
+    {
+        BooleanCallbackProxy proxy = new BooleanCallbackProxy();
+        OneSignalNative.ExitLiveActivity(activityId, response => proxy.OnResponse(true), response => proxy.OnResponse(false));
+        return await proxy;
     }
 }


### PR DESCRIPTION
# Description
## One Line Summary
Reimplement Live Activities in the SDK

## Details

### Motivation
Live activities functionality should still exist in user model, this updates brings forward the existing logic in the `main` branch into the user model code level.

Note the API functions were renamed from `EnterLiveActivity` / `ExitLiveActivity` to `EnterLiveActivityAsync` / `ExitLiveActivityAsync` to keep a consistent naming convention for all async functions.

# Testing
## Manual testing
Ran example app on Android and iOS, ensuring Android prints an error message and iOS will successfully call down to the native iOS SDK to enter/exit live activities.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.