### PR TITLE
Properly fill array of strings on iOS for DeleteTags

### DIFF
--- a/OneSignalSDK.dotnet.iOS/OneSignalImplementation.cs
+++ b/OneSignalSDK.dotnet.iOS/OneSignalImplementation.cs
@@ -200,6 +200,7 @@ namespace OneSignalSDK.DotNet.iOS
          count = 0;
          foreach (var key in keys) {
             nsKeys[count] = NSString.FromData(key, NSStringEncoding.UTF8);
+            count++;
          }
 
          OneSignalNative.DeleteTags(nsKeys, response => proxy.OnResponse(true), response => proxy.OnResponse(false));


### PR DESCRIPTION
# Description
## One Line Summary
Properly fill array of strings on iOS for DeleteTags

## Details

### Motivation
Fixes issue reported in Xamarin SDK: https://github.com/OneSignal/OneSignal-Xamarin-SDK/issues/372

### Scope
This fix is limited to the DeleteTags method on iOS.

# Testing

## Manual testing
Using the example app, drive DeleteTags with various length number of tags.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.