### PR TITLE
User Model Beta 3 release

### DIFF
--- a/OneSignalSDK.DotNet.nuspec
+++ b/OneSignalSDK.DotNet.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
-        <version>5.0.0-beta02</version>
+        <version>5.0.0-beta03</version>
         <id>OneSignalSDK.DotNet</id>
         <title>OneSignal SDK for .Net6+ and Xamarin</title>
         <authors>OneSignal</authors>


### PR DESCRIPTION
In this major version beta release for the OneSignal SDK, we are making a significant shift from a device-centered model to a user-centered model.  A user-centered model allows for more powerful omni-channel integrations within the OneSignal platform.

For information please see the [migration guide](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.0.0-beta03/MIGRATION_GUIDE.md).

## What's Changed Since beta02
* Updated public API method naming #57 
  - Removed `Default` shared instance from public api. Instead all fields can be accessed statically on the OneSignal class.
  - Renamed `RequiresPrivacyConsent` and `PrivacyConsent` to `ConsentRequired` and `ConsentGiven`
  - Updated trigger value to be string instead of object and updated method signatures
  - Updating Notifications to use `addClickListener` and `addForegroundLifecycleListener` from the native code. The `WillDisplay` and `Click` event handlers now fire with new arguments. The `WillDisplayEvent` args allow you to prevent default display of the notification by calling `preventDefault()` and then use `notification.display()` to display the notification after having prevented default.
  - The subscription observer is now a `PushSubscriptionObserver`. The changed event now provides the `previous` and `current` push subscription states.
  - In app message click events now have a `ClickResult` instead of a `ClickAction` parameter.
  - Added `PermissionNative()` to get the exact permission type for iOS devices.


**Full Changelog**: https://github.com/OneSignal/OneSignal-DotNet-SDK/compare/5.0.0-beta02...5.0.0-beta03