### PR TITLE
Add location and IAM modules to native references

### DIFF
--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
@@ -85,5 +85,17 @@
       <ForceLoad>True</ForceLoad>
       <Frameworks>OneSignalCore OneSignalNotifications OneSignalOSCore</Frameworks>
     </NativeReference>
+    <NativeReference Include="OneSignalLocation.xcframework">
+      <Kind>Framework</Kind>
+      <SmartLink>False</SmartLink>
+      <ForceLoad>True</ForceLoad>
+      <Frameworks>OneSignalCore OneSignalNotifications OneSignalOSCore OneSignalUser UIKit</Frameworks>
+    </NativeReference>
+    <NativeReference Include="OneSignalInAppMessages.xcframework">
+      <Kind>Framework</Kind>
+      <SmartLink>False</SmartLink>
+      <ForceLoad>True</ForceLoad>
+      <Frameworks>OneSignalCore OneSignalNotifications OneSignalOSCore OneSignalUser OneSignalOutcomes UIKit WebKit CoreGraphics</Frameworks>
+    </NativeReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description
## One Line Summary
This fixes a build issue when consuming the SDK as a nuget package.

Fixes #68 

## Details
The XCFrameworks for new modules location and IAMs were not included in the native references section of the binding project.

### Motivation
allow builds

# Testing
## Unit testing
none

## Manual testing


# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.