### PR TITLE
[Fix] DictToNSDict string values

### DIFF
--- a/OneSignalSDK.DotNet.iOS/Utilities/ToNativeConversion.cs
+++ b/OneSignalSDK.DotNet.iOS/Utilities/ToNativeConversion.cs
@@ -42,7 +42,7 @@ public static class NativeConversion
         foreach (var entry in dict)
         {
             keys[index] = NSString.FromData(entry.Key, NSStringEncoding.UTF8);
-            values[index] = NSString.FromData(entry.Key, NSStringEncoding.UTF8);
+            values[index] = NSString.FromData(entry.Value, NSStringEncoding.UTF8);
             index++;
         }
 


### PR DESCRIPTION
# Description
## One Line Summary
Fixes the values being sent on iOS when calling AddTriggers, AddAliases, and AddTags.

## Details

### Motivation
Fixes #74

### Scope
OneSignal iOS methods with param`IDictionary<string, string>`
- AddTriggers
- AddAliases
- AddTags

# Testing
## Manual testing
Tested addTags with multiple tags, app deployed with Visual Studio Code with the example app on an iOS simulator iPhone 15 with iOS 17.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.