### PR TITLE
WIP notification service extension service in dotnet

### DIFF
--- a/OneSignalSDK.DotNet.Android.Core.Binding/OneSignalSDK.DotNet.Android.Core.Binding.csproj
+++ b/OneSignalSDK.DotNet.Android.Core.Binding/OneSignalSDK.DotNet.Android.Core.Binding.csproj
@@ -55,6 +55,7 @@
     <LibraryProjectZip Include="Jars\core-release.aar" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.4" />
     <PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="1.8.0.1" />
   </ItemGroup>
 </Project>

--- a/OneSignalSDK.DotNet.Android.Notifications.Binding/Additions/NotificationExtenderBase.cs
+++ b/OneSignalSDK.DotNet.Android.Notifications.Binding/Additions/NotificationExtenderBase.cs
@@ -1,0 +1,9 @@
+using AndroidX.Core.App;
+
+namespace Com.OneSignal.Notifications.Android
+{
+    public abstract class NotificationExtenderBase : Java.Lang.Object, NotificationCompat.IExtender
+    {
+        public abstract NotificationCompat.Builder Extend(NotificationCompat.Builder builder);
+    }
+}

--- a/OneSignalSDK.DotNet.Android.Notifications.Binding/Additions/NotificationServiceExtenderBase.cs
+++ b/OneSignalSDK.DotNet.Android.Notifications.Binding/Additions/NotificationServiceExtenderBase.cs
@@ -1,0 +1,10 @@
+using Android.Content;
+
+namespace Com.OneSignal.Android.Notifications
+{
+    public abstract class NotificationServiceExtenderBase: Java.Lang.Object, Com.OneSignal.Android.Notifications.INotificationServiceExtension
+    {
+        public abstract void OnNotificationReceived(Com.OneSignal.Android.Notifications.INotificationReceivedEvent ev);
+    }
+}
+

--- a/OneSignalSDK.DotNet.Android.Notifications.Binding/OneSignalSDK.DotNet.Android.Notifications.Binding.csproj
+++ b/OneSignalSDK.DotNet.Android.Notifications.Binding/OneSignalSDK.DotNet.Android.Notifications.Binding.csproj
@@ -55,6 +55,10 @@
     <LibraryProjectZip Include="Jars\notifications-release.aar" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Core.Binding\OneSignalSDK.DotNet.Android.Core.Binding.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.4" />
     <PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="1.8.0.1" />
   </ItemGroup>
 </Project>

--- a/OneSignalSDK.DotNet.Android.Notifications.Binding/Transforms/Metadata.xml
+++ b/OneSignalSDK.DotNet.Android.Notifications.Binding/Transforms/Metadata.xml
@@ -1,3 +1,5 @@
 ﻿<metadata>
-	<attr path="/api/package[@name='com.onesignal.notifications']" name="managedName">Com.OneSignal.Android.Notifications</attr>
+  <attr path="/api/package[@name='com.onesignal.notifications']" name="managedName">Com.OneSignal.Android.Notifications</attr>
+
+  <attr path="/api/package[@name='com.onesignal.notifications.internal']/class[@name='Notification']/method[@name='getGroupedNotifications' and count(parameter)=0]" name="return">java.util.List&lt;com.onesignal.notifications.INotification&gt;</attr>
 </metadata>

--- a/OneSignalSDK.DotNet.Android/OneSignalSDK.DotNet.Android.csproj
+++ b/OneSignalSDK.DotNet.Android/OneSignalSDK.DotNet.Android.csproj
@@ -54,8 +54,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="1.8.0.1" />
-    <PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.6.4.2" />
-    <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.6.4.2" />
+    <PackageReference Include="Xamarin.KotlinX.Coroutines.Core" Version="1.8.0.1" />
+    <PackageReference Include="Xamarin.KotlinX.Coroutines.Android" Version="1.8.0.1" />
     <PackageReference Include="Xamarin.AndroidX.CardView" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.14" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.4.0.2" />
@@ -66,5 +66,9 @@
     <PackageReference Include="Xamarin.Google.Dagger" Version="2.41.0.2" />
     <PackageReference Include="Xamarin.GooglePlayServices.Base" Version="118.1.0" />
     <PackageReference Include="Xamarin.AndroidX.Work.Work.Runtime.Ktx" Version="2.7.1.5" />
+    <PackageReference Include="Xamarin.AndroidX.Collection" Version="1.4.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Collection.Ktx" Version="1.4.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Activity" Version="1.7.2" />
+    <PackageReference Include="Xamarin.AndroidX.Activity.Ktx" Version="1.7.2" />
   </ItemGroup>
 </Project>

--- a/OneSignalSDK.DotNet.Android/Utilities/NotificationExtensionAttribute.cs
+++ b/OneSignalSDK.DotNet.Android/Utilities/NotificationExtensionAttribute.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Diagnostics;
+using Android.App;
+using Android.Content;
+
+namespace Com.OneSignal.Android
+{
+    [Serializable]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class NotificationExtensionAttribute : Attribute, Java.Interop.IJniNameProviderAttribute
+    {
+        public string Name { get; set; }
+        public NotificationExtensionAttribute()
+        {
+        }
+    }
+}

--- a/OneSignalSDK.DotNet.nuspec
+++ b/OneSignalSDK.DotNet.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
-        <version>5.1.3</version>
+        <version>5.1.3.1-alpha.1</version>
         <id>OneSignalSDK.DotNet</id>
         <title>OneSignal SDK for .Net6+ and Xamarin</title>
         <authors>OneSignal</authors>

--- a/OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj
+++ b/OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OneSignalSDK.DotNet.Core\OneSignalSDK.DotNet.Core.csproj" />


### PR DESCRIPTION
# Description
## One Line Summary
add possibilities to use the notification service extension from the dotnet world.

## Details
this is based on the work i already done in the "old" xamarin framework
https://github.com/OneSignal/OneSignal-Xamarin-SDK/pull/381

the final usage would be very similar to the one i described in this message:
https://github.com/OneSignal/OneSignal-Xamarin-SDK/pull/381#issuecomment-1841065887
`
YourApp/Platforms/Android/MyOneSignalServiceExtension.cs` :
```cs
using AndroidX.Core.App;
using Com.OneSignal.Android;
using Com.OneSignal.Android.Notifications;
using Com.OneSignal.Notifications.Android;
using Org.Json;

namespace YourApp.Platforms.Android
{
    public class MyExtender : NotificationExtenderBase
    {
        private INotification Notification { get; set; }
        public MyExtender(INotification notif)
        {
            Notification = notif;
        }

        public override NotificationCompat.Builder Extend(NotificationCompat.Builder builder)
        {
            //do some logic with Notification to customize the notif,
            return builder
                //.SetContentTitle("coucou1")
                //.SetContentText("hello2")
                /*.AddAction(new NotificationCompat.Action(null, "coucou", null))*/
                ;
        }
    }

    /* this attribute declare a name in java world for the native onesignal lib 
    to be able to call our c# code. Change it with a name fitting for your app!
    Also, in your AndroidManifest.xml add the following tag 
    with name matching the one you choose under the application tag:
        <meta-data android:name="com.onesignal.NotificationServiceExtension" 
                            android:value="com.your.app.MyOneSignalServiceExtension" />
     */
    [NotificationExtension(Name = "com.your.app.MyOneSignalServiceExtension")]
    public class MyOneSignalServiceExtension : NotificationServiceExtenderBase
    {
        public bool SomeLogicOn(IDisplayableMutableNotification notif, JSONObject additionalData)
        {
            /* implement your logic here if appropriate for your app */
            return false;
        }

        public override void OnNotificationReceived(INotificationReceivedEvent ev)
        {
            var notif = ev.Notification;
            notif.SetExtender(new MyExtender(notif));

            /* example of logic usage to choose to hide the notif or not: */
            bool hideNotif = SomeLogicOn(notif, notif.AdditionalData);

            if (hideNotif)
            {
                ev.PreventDefault();
            }
            else
            {
                notif.Display();
            }
        }
    }
}
```
I did not yet test this usage because i still have dependencies issues, but it used to work in a similar way on the xamarin version.

the main point of this pull-request are:
- i add a dependency on AndroidX.Core in the onesignal core binding library because some types used in the onesignal core binding comes from AndroidX and without this reference the binding are not generated for these API (**the main type required here is NotificationCompat.IExtender** that allow us to customize our notification the the extender through the IDisplayableNotification.setExtender method , without adding this dependency the method setExtender is not generated in the interface )

This dependency is the main reason this MR is still WIP. After adding this dependency, there are lots of conflicts in the final app, stuff about some classes being defined multiple times , some others classes are missing at runtime etc ... If someone is willing to bring help on this point this would be very welcome. In the end, I had to add a lot of dependency just for it to build and i think this is probably too much there must be a dependency/version combination that is optimal and should work in most case but i did not find it yet.


- I add an attribute **NotificationExtensionAttribute**  that inherits from Java.Interop.IJniNameProviderAttribute that allow us to **give a name in the java world** (callable wrapper for our c# service extension class) that will allow the java code to find and **call our c# code from java world** using the metadata defined in manifest. (see [this](https://github.com/dotnet/java-interop/blob/ccafbe6a102a85efe84ceb210b3b8b93e49edbcb/src/Java.Interop.Tools.TypeNameMappings/Java.Interop.Tools.TypeNameMappings/JavaNativeTypeManager.cs#L314-L320))

- i add two classes that act as boilerplates helpers base classes that the programmer (library-user) can use as helper  if they wants to implement the notificationserviceextender and the notification extender 

### Motivation
 fixes #92  this feature is already available in the android sdk but not working yet in dotnet sdk





### Scope
notification service extension



## Manual testing
**RECOMMEND - OPTIONAL -** Explain what scenarios were tested and the environment.
Example: Tested opening a notification while the app was foregrounded, app build with Android Studio 2020.3 with a fresh install of the OneSignal example app on a Pixel 6 with Android 12.

# Affected code checklist
   - [X] Notifications
      - [X] Display
      - [X] Open
      - [X] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [X] I have filled out all **REQUIRED** sections above
   - [X] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.