### PR TITLE
Add netstandard 2.0 to dotnet csproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ Thumbs.db
 *.dotCover
 
 .vs
+/Samples/OneSignalApp/<AndroidSdkPath>
+/Samples/OneSignalApp/<JavaSdkPath>

--- a/OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj
+++ b/OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios</TargetFrameworks>
+    <TargetFrameworks>net7.0;net7.0-android;net7.0-ios;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\OneSignalSDK.DotNet.Core\OneSignalSDK.DotNet.Core.csproj" />


### PR DESCRIPTION
# Description
## One Line Summary
This fixes packaging for release

## Details
The nuspec is expecting a dll for netstandard2.0 for the dotnet project, but one is not created since it wasn't one of the target platforms

### Motivation
Enabled release

### Scope
release packaging

## Manual testing
Successfully packaged 5.2.0 release

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.