### PR TITLE
Remove ActivityKit from NativeReferences in iOS binding

### DIFF
--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
@@ -95,7 +95,7 @@
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <ForceLoad>True</ForceLoad>
-      <Frameworks>OneSignalCore OneSignalOSCore OneSignalUser ActivityKit</Frameworks>
+      <Frameworks>OneSignalCore OneSignalOSCore OneSignalUser</Frameworks>
     </NativeReference>
     <NativeReference Include="OneSignalInAppMessages.xcframework">
       <Kind>Framework</Kind>

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.dotnet.targets
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.dotnet.targets
@@ -53,7 +53,7 @@
               <Kind>Framework</Kind>
               <SmartLink>False</SmartLink>
               <ForceLoad>True</ForceLoad>
-              <Frameworks>OneSignalCore OneSignalOSCore OneSignalUser ActivityKit</Frameworks>
+              <Frameworks>OneSignalCore OneSignalOSCore OneSignalUser</Frameworks>
             </NativeReference>
             <NativeReference Include="$(MSBuildThisFileDirectory)../../res/ios/OneSignalInAppMessages.xcframework">
               <Kind>Framework</Kind>


### PR DESCRIPTION
# Description
## One Line Summary
Fixes an iOS 15 DYLD crash due to not finding ActivityKit

## Details
ActivityKit is not available until iOS 16. By putting it in NativeReferences .Net tries to link it even for iOS 15 devices. We do not need to explicitly link it ourselves and can rely on it being there when the app is launched

### Motivation
fix crash

### Scope
iOS builds on iOS 15 and lower

# Testing
## Manual testing
tested on iOS 15 simulators

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have included test coverage for these changes, or explained why they are not needed
   - [ ] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.