### PR TITLE
chore: rename sdk-actions to sdk-shared

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,7 @@ jobs:
 
   create-release:
     needs: publish
-    uses: OneSignal/sdk-actions/.github/workflows/github-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/github-release.yml@main
     secrets:
       GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -53,9 +53,9 @@ on:
 
 jobs:
   prep:
-    uses: OneSignal/sdk-actions/.github/workflows/prep-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/prep-release.yml@main
     secrets:
-      # Need this cross-repo token (sdk-actions & this repo) to perform changes
+      # Need this cross-repo token (sdk-shared & this repo) to perform changes
       GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:
       target_repo: OneSignal/OneSignal-DotNet-SDK
@@ -80,7 +80,7 @@ jobs:
           token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
 
       - name: Setup Git User
-        uses: OneSignal/sdk-actions/.github/actions/setup-git-user@main
+        uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -145,12 +145,12 @@ jobs:
 
   create-pr:
     needs: [prep, update-version]
-    uses: OneSignal/sdk-actions/.github/workflows/create-release.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/create-release.yml@main
     secrets:
-      # Need this cross-repo token (sdk-actions & this repo) to perform changes
+      # Need this cross-repo token (sdk-shared & this repo) to perform changes
       GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
     with:
-      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-actions)
+      # Need target_repo otherwise caller would set github.repository to the caller itself (e.g. sdk-shared)
       target_repo: OneSignal/OneSignal-DotNet-SDK
       release_branch: ${{ needs.prep.outputs.release_branch }}
       target_branch: ${{ inputs.target_branch }}

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -10,5 +10,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: OneSignal/sdk-actions/.github/workflows/lint-pr-title.yml@main
+    uses: OneSignal/sdk-shared/.github/workflows/lint-pr-title.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
Update all GitHub workflow references from `sdk-actions` to `sdk-shared` to reflect the repo rename.

Made with [Cursor](https://cursor.com)