### PR TITLE
ci: fix release workflow clone collision when called from iOS SDK

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -66,6 +66,9 @@ jobs:
     name: Create Release PR
     needs: prep
     runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: dotnet-sdk
     outputs:
       dotnet_from: ${{ steps.current_versions.outputs.dotnet_from }}
       android_from: ${{ steps.current_versions.outputs.android_from }}
@@ -78,6 +81,7 @@ jobs:
           repository: OneSignal/OneSignal-DotNet-SDK
           ref: ${{ needs.prep.outputs.release_branch }}
           token: ${{ secrets.GH_PUSH_TOKEN || github.token }}
+          path: dotnet-sdk
 
       - name: Setup Git User
         uses: OneSignal/sdk-shared/.github/actions/setup-git-user@main


### PR DESCRIPTION
## Summary
When this workflow is called from the iOS SDK repo via `workflow_call`, the runner workspace path is `.../OneSignal-iOS-SDK/OneSignal-iOS-SDK`. The `git clone ../OneSignal-iOS-SDK` step resolves back to the workspace directory itself, which already exists, causing exit code 128.

This checks out the DotNet SDK into a `dotnet-sdk` subdirectory and sets the default working directory accordingly, so `../OneSignal-iOS-SDK` resolves to a fresh sibling path instead of the workspace root.

## Test plan
- Re-run the iOS SDK publish workflow that triggers this workflow via `workflow_call`
- Verify the "Clone and update native SDKs" step completes without exit code 128


Made with [Cursor](https://cursor.com)