### PR TITLE
feat: [SDK-4775] add location opt-out support

### DIFF
--- a/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
+++ b/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
@@ -51,6 +51,6 @@ public class AndroidLocationManager : ILocationManager
 
     private static void LogLocationModuleNotAvailable(Exception exception)
     {
-        System.Diagnostics.Debug.WriteLine($"{LocationModuleNotAvailable} {exception}");
+        global::Android.Util.Log.Error("OneSignal", $"{LocationModuleNotAvailable} {exception}");
     }
 }

--- a/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
+++ b/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
@@ -1,4 +1,5 @@
-﻿using OneSignalSDK.DotNet.Core;
+﻿using System.Runtime.CompilerServices;
+using OneSignalSDK.DotNet.Core;
 using OneSignalSDK.DotNet.Core.Location;
 using OneSignalNative = Com.OneSignal.Android.OneSignal;
 
@@ -7,7 +8,7 @@ namespace OneSignalSDK.DotNet.Android;
 public class AndroidLocationManager : ILocationManager
 {
     private const string LocationModuleNotAvailable =
-        "OneSignal location module is not available. Add the location dependency to use OneSignal.Location.";
+        "OneSignal location call failed. The location module may not be available; add the location dependency to use OneSignal.Location.";
 
     public bool IsShared
     {
@@ -15,7 +16,7 @@ public class AndroidLocationManager : ILocationManager
         {
             try
             {
-                return OneSignalNative.Location.Shared;
+                return GetShared();
             }
             catch (Exception exception)
             {
@@ -27,7 +28,7 @@ public class AndroidLocationManager : ILocationManager
         {
             try
             {
-                OneSignalNative.Location.Shared = value;
+                SetShared(value);
             }
             catch (Exception exception)
             {
@@ -40,10 +41,7 @@ public class AndroidLocationManager : ILocationManager
     {
         try
         {
-            var consumer = new AndroidBoolConsumer();
-            OneSignalNative.Location.RequestPermission(
-                Com.OneSignal.Android.Continue.With(consumer)
-            );
+            RequestNativePermission();
         }
         catch (Exception exception)
         {
@@ -54,5 +52,18 @@ public class AndroidLocationManager : ILocationManager
     private static void LogLocationModuleNotAvailable(Exception exception)
     {
         global::Android.Util.Log.Error("OneSignal", $"{LocationModuleNotAvailable} {exception}");
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool GetShared() => OneSignalNative.Location.Shared;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SetShared(bool shared) => OneSignalNative.Location.Shared = shared;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RequestNativePermission()
+    {
+        var consumer = new AndroidBoolConsumer();
+        OneSignalNative.Location.RequestPermission(Com.OneSignal.Android.Continue.With(consumer));
     }
 }

--- a/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
+++ b/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
@@ -41,7 +41,9 @@ public class AndroidLocationManager : ILocationManager
         try
         {
             var consumer = new AndroidBoolConsumer();
-            OneSignalNative.Location.RequestPermission(Com.OneSignal.Android.Continue.With(consumer));
+            OneSignalNative.Location.RequestPermission(
+                Com.OneSignal.Android.Continue.With(consumer)
+            );
         }
         catch (Exception exception)
         {

--- a/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
+++ b/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
@@ -8,7 +8,7 @@ namespace OneSignalSDK.DotNet.Android;
 public class AndroidLocationManager : ILocationManager
 {
     private const string LocationModuleNotAvailable =
-        "OneSignal location call failed. The location module may not be available; add the location dependency to use OneSignal.Location.";
+        "OneSignal.Location call failed. The location module may not be included in this build.";
 
     public bool IsShared
     {

--- a/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
+++ b/OneSignalSDK.DotNet.Android/AndroidLocationManager.cs
@@ -6,15 +6,51 @@ namespace OneSignalSDK.DotNet.Android;
 
 public class AndroidLocationManager : ILocationManager
 {
+    private const string LocationModuleNotAvailable =
+        "OneSignal location module is not available. Add the location dependency to use OneSignal.Location.";
+
     public bool IsShared
     {
-        get => OneSignalNative.Location.Shared;
-        set => OneSignalNative.Location.Shared = value;
+        get
+        {
+            try
+            {
+                return OneSignalNative.Location.Shared;
+            }
+            catch (Exception exception)
+            {
+                LogLocationModuleNotAvailable(exception);
+                return false;
+            }
+        }
+        set
+        {
+            try
+            {
+                OneSignalNative.Location.Shared = value;
+            }
+            catch (Exception exception)
+            {
+                LogLocationModuleNotAvailable(exception);
+            }
+        }
     }
 
     public void RequestPermission()
     {
-        var consumer = new AndroidBoolConsumer();
-        OneSignalNative.Location.RequestPermission(Com.OneSignal.Android.Continue.With(consumer));
+        try
+        {
+            var consumer = new AndroidBoolConsumer();
+            OneSignalNative.Location.RequestPermission(Com.OneSignal.Android.Continue.With(consumer));
+        }
+        catch (Exception exception)
+        {
+            LogLocationModuleNotAvailable(exception);
+        }
+    }
+
+    private static void LogLocationModuleNotAvailable(Exception exception)
+    {
+        System.Diagnostics.Debug.WriteLine($"{LocationModuleNotAvailable} {exception}");
     }
 }

--- a/OneSignalSDK.DotNet.Android/OneSignalSDK.DotNet.Android.csproj
+++ b/OneSignalSDK.DotNet.Android/OneSignalSDK.DotNet.Android.csproj
@@ -44,7 +44,10 @@
     <ProjectReference Include="..\OneSignalSDK.DotNet.Android.InAppMessages.Binding\OneSignalSDK.DotNet.Android.InAppMessages.Binding.csproj">
       <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>
     </ProjectReference>
-    <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Location.Binding\OneSignalSDK.DotNet.Android.Location.Binding.csproj">
+    <ProjectReference
+      Include="..\OneSignalSDK.DotNet.Android.Location.Binding\OneSignalSDK.DotNet.Android.Location.Binding.csproj"
+      Condition="'$(OneSignalDisableLocation)' != 'true'"
+    >
       <ReferenceSourceTarget>ProjectReference</ReferenceSourceTarget>
     </ProjectReference>
     <ProjectReference Include="..\OneSignalSDK.DotNet.Android.Notifications.Binding\OneSignalSDK.DotNet.Android.Notifications.Binding.csproj">

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
@@ -85,7 +85,10 @@
       <ForceLoad>True</ForceLoad>
       <Frameworks>OneSignalCore OneSignalNotifications OneSignalOSCore</Frameworks>
     </NativeReference>
-    <NativeReference Include="OneSignalLocation.xcframework">
+    <NativeReference
+      Include="OneSignalLocation.xcframework"
+      Condition="'$(OneSignalDisableLocation)' != 'true'"
+    >
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
       <ForceLoad>True</ForceLoad>

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.dotnet.targets
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.dotnet.targets
@@ -43,7 +43,10 @@
         <ForceLoad>True</ForceLoad>
         <Frameworks>OneSignalCore OneSignalNotifications OneSignalOSCore</Frameworks>
       </NativeReference>
-      <NativeReference Include="$(MSBuildThisFileDirectory)../../res/ios/OneSignalLocation.xcframework">
+      <NativeReference
+        Include="$(MSBuildThisFileDirectory)../../res/ios/OneSignalLocation.xcframework"
+        Condition="'$(OneSignalDisableLocation)' != 'true'"
+      >
         <Kind>Framework</Kind>
         <SmartLink>False</SmartLink>
         <ForceLoad>True</ForceLoad>

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.dotnet.targets
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.dotnet.targets
@@ -66,4 +66,5 @@
       </NativeReference>
     </ItemGroup>
   </Target>
+
 </Project>

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.dotnet.targets
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.dotnet.targets
@@ -66,5 +66,4 @@
       </NativeReference>
     </ItemGroup>
   </Target>
-
 </Project>

--- a/OneSignalSDK.DotNet.iOS/iOSLocationManager.cs
+++ b/OneSignalSDK.DotNet.iOS/iOSLocationManager.cs
@@ -1,4 +1,5 @@
-﻿using OneSignalSDK.DotNet.Core;
+﻿using System.Runtime.CompilerServices;
+using OneSignalSDK.DotNet.Core;
 using OneSignalSDK.DotNet.Core.Location;
 using OneSignalNative = Com.OneSignal.iOS.OneSignal;
 
@@ -7,7 +8,7 @@ namespace OneSignalSDK.DotNet.iOS;
 public class iOSLocationManager : ILocationManager
 {
     private const string LocationModuleNotAvailable =
-        "OneSignal location module is not available. Add the location dependency to use OneSignal.Location.";
+        "OneSignal location call failed. The location module may not be available; add the location dependency to use OneSignal.Location.";
 
     public bool IsShared
     {
@@ -15,7 +16,7 @@ public class iOSLocationManager : ILocationManager
         {
             try
             {
-                return OneSignalNative.Location.IsShared;
+                return GetShared();
             }
             catch (Exception exception)
             {
@@ -27,7 +28,7 @@ public class iOSLocationManager : ILocationManager
         {
             try
             {
-                OneSignalNative.Location.SetShared(value);
+                SetShared(value);
             }
             catch (Exception exception)
             {
@@ -40,7 +41,7 @@ public class iOSLocationManager : ILocationManager
     {
         try
         {
-            OneSignalNative.Location.RequestPermission();
+            RequestNativePermission();
         }
         catch (Exception exception)
         {
@@ -50,6 +51,15 @@ public class iOSLocationManager : ILocationManager
 
     private static void LogLocationModuleNotAvailable(Exception exception)
     {
-        System.Diagnostics.Debug.WriteLine($"{LocationModuleNotAvailable} {exception}");
+        Console.Error.WriteLine($"{LocationModuleNotAvailable} {exception}");
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool GetShared() => OneSignalNative.Location.IsShared;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SetShared(bool shared) => OneSignalNative.Location.SetShared(shared);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void RequestNativePermission() => OneSignalNative.Location.RequestPermission();
 }

--- a/OneSignalSDK.DotNet.iOS/iOSLocationManager.cs
+++ b/OneSignalSDK.DotNet.iOS/iOSLocationManager.cs
@@ -6,14 +6,50 @@ namespace OneSignalSDK.DotNet.iOS;
 
 public class iOSLocationManager : ILocationManager
 {
+    private const string LocationModuleNotAvailable =
+        "OneSignal location module is not available. Add the location dependency to use OneSignal.Location.";
+
     public bool IsShared
     {
-        get => OneSignalNative.Location.IsShared;
-        set => OneSignalNative.Location.SetShared(value);
+        get
+        {
+            try
+            {
+                return OneSignalNative.Location.IsShared;
+            }
+            catch (Exception exception)
+            {
+                LogLocationModuleNotAvailable(exception);
+                return false;
+            }
+        }
+        set
+        {
+            try
+            {
+                OneSignalNative.Location.SetShared(value);
+            }
+            catch (Exception exception)
+            {
+                LogLocationModuleNotAvailable(exception);
+            }
+        }
     }
 
     public void RequestPermission()
     {
-        OneSignalNative.Location.RequestPermission();
+        try
+        {
+            OneSignalNative.Location.RequestPermission();
+        }
+        catch (Exception exception)
+        {
+            LogLocationModuleNotAvailable(exception);
+        }
+    }
+
+    private static void LogLocationModuleNotAvailable(Exception exception)
+    {
+        System.Diagnostics.Debug.WriteLine($"{LocationModuleNotAvailable} {exception}");
     }
 }

--- a/OneSignalSDK.DotNet.iOS/iOSLocationManager.cs
+++ b/OneSignalSDK.DotNet.iOS/iOSLocationManager.cs
@@ -8,7 +8,7 @@ namespace OneSignalSDK.DotNet.iOS;
 public class iOSLocationManager : ILocationManager
 {
     private const string LocationModuleNotAvailable =
-        "OneSignal location call failed. The location module may not be available; add the location dependency to use OneSignal.Location.";
+        "OneSignal.Location call failed. The location module may not be included in this build.";
 
     public bool IsShared
     {

--- a/OneSignalSDK.DotNet.nuspec
+++ b/OneSignalSDK.DotNet.nuspec
@@ -99,5 +99,8 @@
         <!-- This is a .target files that gets used by project that consumes the NuGet package.
              This copies out the OneSignal.xcframework from the resources folder and adds a NativeReference to it in the app project. -->
         <file src="OneSignalSDK.DotNet.iOS.Binding\OneSignalSDK.DotNet.targets" target="build\net10.0-ios12.2\" />
+
+        <!-- Removes optional Android location assets when OneSignalDisableLocation=true. -->
+        <file src="OneSignalSDK.DotNet\OneSignalSDK.DotNet.Android.targets" target="build\net10.0-android21.0\OneSignalSDK.DotNet.targets" />
     </files>    
 </package>

--- a/OneSignalSDK.DotNet/OneSignalSDK.DotNet.Android.targets
+++ b/OneSignalSDK.DotNet/OneSignalSDK.DotNet.Android.targets
@@ -1,0 +1,31 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target
+    Name="OneSignalRemoveAndroidLocationAssets"
+    AfterTargets="ResolvePackageAssets"
+    BeforeTargets="ResolveReferences;_ResolveLibraryProjectImports"
+    Condition="'$(OneSignalDisableLocation)' == 'true'"
+  >
+    <ItemGroup>
+      <Reference
+        Remove="@(Reference)"
+        Condition="'%(Reference.Filename)' == 'OneSignalSDK.DotNet.Android.Location.Binding'"
+      />
+      <ReferencePath
+        Remove="@(ReferencePath)"
+        Condition="'%(ReferencePath.Filename)' == 'OneSignalSDK.DotNet.Android.Location.Binding'"
+      />
+      <ReferenceCopyLocalPaths
+        Remove="@(ReferenceCopyLocalPaths)"
+        Condition="'%(ReferenceCopyLocalPaths.Filename)' == 'OneSignalSDK.DotNet.Android.Location.Binding'"
+      />
+      <AndroidLibrary
+        Remove="@(AndroidLibrary)"
+        Condition="'%(AndroidLibrary.Filename)%(AndroidLibrary.Extension)' == 'location-release.aar'"
+      />
+      <AndroidAarLibrary
+        Remove="@(AndroidAarLibrary)"
+        Condition="'%(AndroidAarLibrary.Filename)%(AndroidAarLibrary.Extension)' == 'location-release.aar'"
+      />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ Xamarin projects: See the [Setup Documentation](https://documentation.onesignal.
 
 See OneSignal's [.NET SDK API](https://documentation.onesignal.com/docs/net-client-sdk) page for a list of all available methods.
 
+#### Disable Location Module
+
+By default, `OneSignalSDK.DotNet` includes OneSignal's native location module so `OneSignal.Location` works without extra setup. If your app does not use location features, you can exclude the native location module from iOS and Android builds with an MSBuild property in your app project:
+
+```xml
+<PropertyGroup>
+  <OneSignalDisableLocation>true</OneSignalDisableLocation>
+</PropertyGroup>
+```
+
+When disabled, `OneSignal.Location.RequestPermission()` and `OneSignal.Location.IsShared = value` no-op on native builds without the location module, and `OneSignal.Location.IsShared` returns `false`.
+
+This is an MSBuild-only setting; Gradle properties are not supported for disabling the .NET SDK location module.
+
 #### Change Log
 
 See this repository's [release tags](https://github.com/OneSignal/OneSignal-DotNet-SDK/releases) for a complete change log of every released version.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ By default, `OneSignalSDK.DotNet` includes OneSignal's native location module so
 
 When disabled, `OneSignal.Location.RequestPermission()` and `OneSignal.Location.IsShared = value` no-op on native builds without the location module, and `OneSignal.Location.IsShared` returns `false`.
 
+For regular development, make sure the property is set for the app build that consumes the SDK. If you are building from source with project references or scripts, pass the property to the `dotnet build` command so it applies to the referenced SDK projects too:
+
+```sh
+dotnet build -f net10.0-ios -p:OneSignalDisableLocation=true
+dotnet build -f net10.0-android -p:OneSignalDisableLocation=true
+```
+
+In CI, include the `OneSignalDisableLocation` value in build cache keys, or clean build outputs when toggling it. This avoids restoring stale iOS app bundles, Android intermediates, or `bin`/`obj` outputs that were produced with the location module enabled.
+
 This is an MSBuild-only setting; Gradle properties are not supported for disabling the .NET SDK location module.
 
 #### Change Log

--- a/examples/demo-no-location/.env.example
+++ b/examples/demo-no-location/.env.example
@@ -1,0 +1,1 @@
+ONESIGNAL_APP_ID=your-onesignal-app-id

--- a/examples/demo-no-location/App.xaml
+++ b/examples/demo-no-location/App.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Application
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  x:Class="OneSignalDemoNoLocation.App"
+>
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
+        <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
+</Application>

--- a/examples/demo-no-location/App.xaml.cs
+++ b/examples/demo-no-location/App.xaml.cs
@@ -1,0 +1,17 @@
+namespace OneSignalDemoNoLocation;
+
+public partial class App : Application
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public App(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+        InitializeComponent();
+    }
+
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        return new Window(_serviceProvider.GetRequiredService<MainPage>());
+    }
+}

--- a/examples/demo-no-location/DotEnv.cs
+++ b/examples/demo-no-location/DotEnv.cs
@@ -1,0 +1,57 @@
+namespace OneSignalDemoNoLocation;
+
+public static class DotEnv
+{
+    private static readonly Dictionary<string, string> Values = new();
+    private static bool _loaded;
+
+    public static void Load()
+    {
+        if (_loaded)
+            return;
+
+        try
+        {
+            using var stream = Task.Run(() => FileSystem.OpenAppPackageFileAsync("appenv"))
+                .GetAwaiter()
+                .GetResult();
+            using var reader = new StreamReader(stream);
+
+            foreach (
+                var line in reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            )
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith('#') || !trimmed.Contains('='))
+                    continue;
+
+                var eqIndex = trimmed.IndexOf('=');
+                var key = trimmed[..eqIndex].Trim();
+                var value = trimmed[(eqIndex + 1)..].Trim();
+
+                if (
+                    value.Length >= 2
+                    && (
+                        (value[0] == '"' && value[^1] == '"')
+                        || (value[0] == '\'' && value[^1] == '\'')
+                    )
+                )
+                {
+                    value = value[1..^1];
+                }
+
+                Values[key] = value;
+            }
+        }
+        catch
+        {
+            // Missing .env is expected for first-time demo setup.
+        }
+        finally
+        {
+            _loaded = true;
+        }
+    }
+
+    public static string Get(string key) => Values.TryGetValue(key, out var value) ? value : "";
+}

--- a/examples/demo-no-location/MainPage.xaml
+++ b/examples/demo-no-location/MainPage.xaml
@@ -29,12 +29,7 @@
       Padding="16,14"
       Spacing="2"
     >
-      <Label
-        Text="OneSignal"
-        TextColor="White"
-        FontSize="22"
-        FontAttributes="Bold"
-      />
+      <Label Text="OneSignal" TextColor="White" FontSize="22" FontAttributes="Bold" />
       <Label Text="No-Location Demo" TextColor="White" FontSize="14" />
     </VerticalStackLayout>
 
@@ -45,11 +40,7 @@
           <Border Style="{StaticResource CardBorderStyle}">
             <Grid Padding="12" ColumnDefinitions="Auto,*" ColumnSpacing="8">
               <Label Text="App ID" Style="{StaticResource LabelStyle}" />
-              <Label
-                x:Name="AppIdLabel"
-                Grid.Column="1"
-                Style="{StaticResource ValueStyle}"
-              />
+              <Label x:Name="AppIdLabel" Grid.Column="1" Style="{StaticResource ValueStyle}" />
             </Grid>
           </Border>
         </VerticalStackLayout>
@@ -71,11 +62,7 @@
 
               <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
                 <Label Text="Push ID" Style="{StaticResource LabelStyle}" />
-                <Label
-                  x:Name="PushIdLabel"
-                  Grid.Column="1"
-                  Style="{StaticResource ValueStyle}"
-                />
+                <Label x:Name="PushIdLabel" Grid.Column="1" Style="{StaticResource ValueStyle}" />
               </Grid>
 
               <Button

--- a/examples/demo-no-location/MainPage.xaml
+++ b/examples/demo-no-location/MainPage.xaml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  x:Class="OneSignalDemoNoLocation.MainPage"
+  BackgroundColor="{StaticResource OsLightBackground}"
+>
+  <Grid RowDefinitions="Auto,*">
+    <VerticalStackLayout
+      Grid.Row="0"
+      BackgroundColor="{StaticResource OsPrimary}"
+      Padding="16,14"
+      Spacing="2"
+    >
+      <Label
+        Text="OneSignal"
+        TextColor="White"
+        FontSize="22"
+        FontAttributes="Bold"
+      />
+      <Label Text="No-Location Demo" TextColor="White" FontSize="14" />
+    </VerticalStackLayout>
+
+    <ScrollView Grid.Row="1">
+      <VerticalStackLayout Padding="16" Spacing="24">
+        <VerticalStackLayout Spacing="8">
+          <Label Text="APP" Style="{StaticResource SectionHeaderStyle}" />
+          <Border Style="{StaticResource CardBorderStyle}">
+            <Grid Padding="12" ColumnDefinitions="Auto,*" ColumnSpacing="8">
+              <Label Text="App ID" Style="{StaticResource LabelStyle}" />
+              <Label
+                x:Name="AppIdLabel"
+                Grid.Column="1"
+                Style="{StaticResource ValueStyle}"
+              />
+            </Grid>
+          </Border>
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="8">
+          <Label Text="PUSH" Style="{StaticResource SectionHeaderStyle}" />
+          <Border Style="{StaticResource CardBorderStyle}">
+            <VerticalStackLayout Padding="12" Spacing="8">
+              <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                <Label Text="Permission" Style="{StaticResource LabelStyle}" />
+                <Label
+                  x:Name="PermissionLabel"
+                  Grid.Column="1"
+                  Style="{StaticResource ValueStyle}"
+                />
+              </Grid>
+
+              <BoxView HeightRequest="1" Color="{StaticResource OsDivider}" />
+
+              <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
+                <Label Text="Push ID" Style="{StaticResource LabelStyle}" />
+                <Label
+                  x:Name="PushIdLabel"
+                  Grid.Column="1"
+                  Style="{StaticResource ValueStyle}"
+                />
+              </Grid>
+
+              <Button
+                x:Name="RequestPermissionButton"
+                Text="REQUEST PERMISSION"
+                Style="{StaticResource PrimaryButtonStyle}"
+                Clicked="OnRequestPermissionClicked"
+              />
+              <ActivityIndicator
+                x:Name="RequestPermissionSpinner"
+                IsVisible="False"
+                Color="{StaticResource OsPrimary}"
+              />
+
+              <Button
+                x:Name="SendNotificationButton"
+                Text="SEND TEST NOTIFICATION"
+                Style="{StaticResource PrimaryButtonStyle}"
+                Clicked="OnSendNotificationClicked"
+              />
+              <ActivityIndicator
+                x:Name="SendNotificationSpinner"
+                IsVisible="False"
+                Color="{StaticResource OsPrimary}"
+              />
+            </VerticalStackLayout>
+          </Border>
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="8">
+          <Label Text="LOCATION MODULE" Style="{StaticResource SectionHeaderStyle}" />
+          <Border Style="{StaticResource CardBorderStyle}">
+            <VerticalStackLayout Padding="12" Spacing="12">
+              <Label
+                Text="This demo initializes OneSignal and requests notification permission only when you tap the button above. Native builds exclude the location module. The location test call may not show an app error; check Android Logcat or Xcode logs for native diagnostics."
+                Style="{StaticResource BodyStyle}"
+              />
+              <Label
+                x:Name="LocationStatusLabel"
+                Text="Location test not run"
+                Style="{StaticResource BodyStyle}"
+              />
+              <Button
+                Text="TEST LOCATION REQUEST"
+                Style="{StaticResource OutlineButtonStyle}"
+                Clicked="OnTestLocationClicked"
+              />
+            </VerticalStackLayout>
+          </Border>
+        </VerticalStackLayout>
+      </VerticalStackLayout>
+    </ScrollView>
+  </Grid>
+</ContentPage>

--- a/examples/demo-no-location/MainPage.xaml
+++ b/examples/demo-no-location/MainPage.xaml
@@ -96,11 +96,6 @@
                 Style="{StaticResource PrimaryButtonStyle}"
                 Clicked="OnSendNotificationClicked"
               />
-              <ActivityIndicator
-                x:Name="SendNotificationSpinner"
-                IsVisible="False"
-                Color="{StaticResource OsPrimary}"
-              />
             </VerticalStackLayout>
           </Border>
         </VerticalStackLayout>

--- a/examples/demo-no-location/MainPage.xaml
+++ b/examples/demo-no-location/MainPage.xaml
@@ -2,12 +2,29 @@
 <ContentPage
   xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+  xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
   x:Class="OneSignalDemoNoLocation.MainPage"
   BackgroundColor="{StaticResource OsLightBackground}"
+  SafeAreaEdges="None"
 >
-  <Grid RowDefinitions="Auto,*">
-    <VerticalStackLayout
+  <ContentPage.Behaviors>
+    <toolkit:StatusBarBehavior
+      StatusBarColor="{StaticResource OsPrimary}"
+      StatusBarStyle="LightContent"
+    />
+  </ContentPage.Behaviors>
+
+  <Grid RowDefinitions="Auto,Auto,*" SafeAreaEdges="None">
+    <BoxView
+      x:Name="TopSafeArea"
       Grid.Row="0"
+      BackgroundColor="{StaticResource OsPrimary}"
+      HeightRequest="0"
+    />
+
+    <VerticalStackLayout
+      x:Name="Header"
+      Grid.Row="1"
       BackgroundColor="{StaticResource OsPrimary}"
       Padding="16,14"
       Spacing="2"
@@ -21,8 +38,8 @@
       <Label Text="No-Location Demo" TextColor="White" FontSize="14" />
     </VerticalStackLayout>
 
-    <ScrollView Grid.Row="1">
-      <VerticalStackLayout Padding="16" Spacing="24">
+    <ScrollView Grid.Row="2" SafeAreaEdges="None">
+      <VerticalStackLayout x:Name="ContentStack" Padding="16" Spacing="24">
         <VerticalStackLayout Spacing="8">
           <Label Text="APP" Style="{StaticResource SectionHeaderStyle}" />
           <Border Style="{StaticResource CardBorderStyle}">

--- a/examples/demo-no-location/MainPage.xaml.cs
+++ b/examples/demo-no-location/MainPage.xaml.cs
@@ -1,0 +1,169 @@
+using System.Text;
+using System.Text.Json;
+using OneSignalSDK.DotNet;
+using OneSignalSDK.DotNet.Core.Notifications;
+using OneSignalSDK.DotNet.Core.User.Subscriptions;
+
+namespace OneSignalDemoNoLocation;
+
+public partial class MainPage : ContentPage
+{
+    private readonly string _appId;
+
+    public MainPage(AppConfig config)
+    {
+        InitializeComponent();
+
+        _appId = config.OneSignalAppId;
+        AppIdLabel.Text = _appId;
+
+        OneSignal.Notifications.PermissionChanged += OnPermissionChanged;
+        OneSignal.User.PushSubscription.Changed += OnPushSubscriptionChanged;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        RefreshPushState();
+    }
+
+    private void RefreshPushState()
+    {
+        PermissionLabel.Text = OneSignal.Notifications.Permission ? "Granted" : "Not granted";
+        PushIdLabel.Text = FormatValue(OneSignal.User.PushSubscription.Id);
+    }
+
+    private async void OnRequestPermissionClicked(object? sender, EventArgs e)
+    {
+        SetBusy(RequestPermissionButton, RequestPermissionSpinner, true);
+        try
+        {
+            await OneSignal.Notifications.RequestPermissionAsync(false);
+            RefreshPushState();
+        }
+        catch (Exception exception)
+        {
+            await DisplayAlert("Permission Request Failed", exception.Message, "OK");
+        }
+        finally
+        {
+            SetBusy(RequestPermissionButton, RequestPermissionSpinner, false);
+        }
+    }
+
+    private async void OnSendNotificationClicked(object? sender, EventArgs e)
+    {
+        if (IsPlaceholder(_appId))
+        {
+            await DisplayAlert(
+                "Configure OneSignal",
+                "Set ONESIGNAL_APP_ID in .env before sending a test push.",
+                "OK"
+            );
+            return;
+        }
+
+        if (!OneSignal.Notifications.Permission)
+        {
+            await DisplayAlert(
+                "Notifications Disabled",
+                "Request notification permission before sending a test push.",
+                "OK"
+            );
+            return;
+        }
+
+        var pushSubscriptionId = OneSignal.User.PushSubscription.Id;
+        if (string.IsNullOrWhiteSpace(pushSubscriptionId))
+        {
+            await DisplayAlert(
+                "No Push Subscription",
+                "Allow notifications, then wait for a push ID.",
+                "OK"
+            );
+            return;
+        }
+
+        SetBusy(SendNotificationButton, SendNotificationSpinner, true);
+        try
+        {
+            var response = await SendTestNotificationAsync(pushSubscriptionId);
+            if (response.IsSuccessStatusCode)
+            {
+                await DisplayAlert("Sent", "Test notification requested.", "OK");
+                return;
+            }
+
+            var message = await response.Content.ReadAsStringAsync();
+            await DisplayAlert("Send Failed", message, "OK");
+        }
+        catch (Exception exception)
+        {
+            await DisplayAlert("Send Failed", exception.Message, "OK");
+        }
+        finally
+        {
+            SetBusy(SendNotificationButton, SendNotificationSpinner, false);
+        }
+    }
+
+    private void OnTestLocationClicked(object? sender, EventArgs e)
+    {
+        try
+        {
+            OneSignal.Location.RequestPermission();
+            LocationStatusLabel.Text = $"Location request completed. IsShared={OneSignal.Location.IsShared}";
+        }
+        catch (Exception exception)
+        {
+            LocationStatusLabel.Text = $"Location request failed: {exception.Message}";
+        }
+    }
+
+    private async Task<HttpResponseMessage> SendTestNotificationAsync(string pushSubscriptionId)
+    {
+        using var client = new HttpClient();
+        client.DefaultRequestHeaders.Add("Accept", "application/vnd.onesignal.v1+json");
+
+        var payload = new Dictionary<string, object>
+        {
+            ["app_id"] = _appId,
+            ["include_subscription_ids"] = new[] { pushSubscriptionId },
+            ["headings"] = new Dictionary<string, string>
+            {
+                ["en"] = "OneSignal No-Location Demo",
+            },
+            ["contents"] = new Dictionary<string, string>
+            {
+                ["en"] = "This test push was sent without linking the location module.",
+            },
+        };
+
+        var json = JsonSerializer.Serialize(payload);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        return await client.PostAsync("https://onesignal.com/api/v1/notifications", content);
+    }
+
+    private void OnPermissionChanged(object? sender, NotificationPermissionChangedEventArgs args)
+    {
+        MainThread.BeginInvokeOnMainThread(RefreshPushState);
+    }
+
+    private void OnPushSubscriptionChanged(object? sender, PushSubscriptionChangedEventArgs args)
+    {
+        MainThread.BeginInvokeOnMainThread(RefreshPushState);
+    }
+
+    private static void SetBusy(Button button, ActivityIndicator spinner, bool busy)
+    {
+        button.IsEnabled = !busy;
+        button.IsVisible = !busy;
+        spinner.IsRunning = busy;
+        spinner.IsVisible = busy;
+    }
+
+    private static string FormatValue(string value) => string.IsNullOrWhiteSpace(value) ? "-" : value;
+
+    private static bool IsPlaceholder(string value) =>
+        value.Trim().StartsWith("YOUR-", StringComparison.OrdinalIgnoreCase);
+}

--- a/examples/demo-no-location/MainPage.xaml.cs
+++ b/examples/demo-no-location/MainPage.xaml.cs
@@ -126,7 +126,7 @@ public partial class MainPage : ContentPage
         try
         {
             OneSignal.Location.RequestPermission();
-            LocationStatusLabel.Text = $"Location request completed. IsShared={OneSignal.Location.IsShared}";
+            LocationStatusLabel.Text = "Location request completed without linking the location module.";
         }
         catch (Exception exception)
         {

--- a/examples/demo-no-location/MainPage.xaml.cs
+++ b/examples/demo-no-location/MainPage.xaml.cs
@@ -126,7 +126,8 @@ public partial class MainPage : ContentPage
         try
         {
             OneSignal.Location.RequestPermission();
-            LocationStatusLabel.Text = "Location request completed without linking the location module.";
+            LocationStatusLabel.Text =
+                "Location request completed without linking the location module.";
         }
         catch (Exception exception)
         {
@@ -143,10 +144,7 @@ public partial class MainPage : ContentPage
         {
             ["app_id"] = _appId,
             ["include_subscription_ids"] = new[] { pushSubscriptionId },
-            ["headings"] = new Dictionary<string, string>
-            {
-                ["en"] = "OneSignal No-Location Demo",
-            },
+            ["headings"] = new Dictionary<string, string> { ["en"] = "OneSignal No-Location Demo" },
             ["contents"] = new Dictionary<string, string>
             {
                 ["en"] = "This test push was sent without linking the location module.",
@@ -176,7 +174,8 @@ public partial class MainPage : ContentPage
         spinner.IsVisible = busy;
     }
 
-    private static string FormatValue(string value) => string.IsNullOrWhiteSpace(value) ? "-" : value;
+    private static string FormatValue(string value) =>
+        string.IsNullOrWhiteSpace(value) ? "-" : value;
 
     private static bool IsPlaceholder(string value) =>
         value.Trim().StartsWith("YOUR-", StringComparison.OrdinalIgnoreCase);
@@ -185,9 +184,7 @@ public partial class MainPage : ContentPage
     private static Thickness GetWindowSafeAreaInsets()
     {
         var window = UIApplication
-            .SharedApplication
-            .ConnectedScenes
-            .OfType<UIWindowScene>()
+            .SharedApplication.ConnectedScenes.OfType<UIWindowScene>()
             .SelectMany(scene => scene.Windows)
             .FirstOrDefault(window => window.IsKeyWindow);
 

--- a/examples/demo-no-location/MainPage.xaml.cs
+++ b/examples/demo-no-location/MainPage.xaml.cs
@@ -3,6 +3,9 @@ using System.Text.Json;
 using OneSignalSDK.DotNet;
 using OneSignalSDK.DotNet.Core.Notifications;
 using OneSignalSDK.DotNet.Core.User.Subscriptions;
+#if IOS
+using UIKit;
+#endif
 
 namespace OneSignalDemoNoLocation;
 
@@ -19,6 +22,17 @@ public partial class MainPage : ContentPage
 
         OneSignal.Notifications.PermissionChanged += OnPermissionChanged;
         OneSignal.User.PushSubscription.Changed += OnPushSubscriptionChanged;
+    }
+
+    protected override void OnSizeAllocated(double width, double height)
+    {
+        base.OnSizeAllocated(width, height);
+
+#if IOS
+        var safeArea = GetWindowSafeAreaInsets();
+        TopSafeArea.HeightRequest = safeArea.Top;
+        ContentStack.Padding = new Thickness(16, 16, 16, safeArea.Bottom + 16);
+#endif
     }
 
     protected override void OnAppearing()
@@ -166,4 +180,19 @@ public partial class MainPage : ContentPage
 
     private static bool IsPlaceholder(string value) =>
         value.Trim().StartsWith("YOUR-", StringComparison.OrdinalIgnoreCase);
+
+#if IOS
+    private static Thickness GetWindowSafeAreaInsets()
+    {
+        var window = UIApplication
+            .SharedApplication
+            .ConnectedScenes
+            .OfType<UIWindowScene>()
+            .SelectMany(scene => scene.Windows)
+            .FirstOrDefault(window => window.IsKeyWindow);
+
+        var insets = window?.SafeAreaInsets ?? UIEdgeInsets.Zero;
+        return new Thickness(insets.Left, insets.Top, insets.Right, insets.Bottom);
+    }
+#endif
 }

--- a/examples/demo-no-location/MainPage.xaml.cs
+++ b/examples/demo-no-location/MainPage.xaml.cs
@@ -98,7 +98,7 @@ public partial class MainPage : ContentPage
             return;
         }
 
-        SetBusy(SendNotificationButton, SendNotificationSpinner, true);
+        SendNotificationButton.IsEnabled = false;
         try
         {
             var response = await SendTestNotificationAsync(pushSubscriptionId);
@@ -117,7 +117,7 @@ public partial class MainPage : ContentPage
         }
         finally
         {
-            SetBusy(SendNotificationButton, SendNotificationSpinner, false);
+            SendNotificationButton.IsEnabled = true;
         }
     }
 

--- a/examples/demo-no-location/MauiProgram.cs
+++ b/examples/demo-no-location/MauiProgram.cs
@@ -1,0 +1,32 @@
+using OneSignalSDK.DotNet;
+using OsLogLevel = OneSignalSDK.DotNet.Core.Debug.LogLevel;
+
+namespace OneSignalDemoNoLocation;
+
+public static class MauiProgram
+{
+    private const string DefaultAppId = "YOUR-ONESIGNAL-APP-ID";
+
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+
+        builder.UseMauiApp<App>();
+
+        DotEnv.Load();
+
+        var envAppId = DotEnv.Get("ONESIGNAL_APP_ID");
+        var appId = string.IsNullOrWhiteSpace(envAppId) ? DefaultAppId : envAppId.Trim();
+
+        OneSignal.Debug.LogLevel = OsLogLevel.VERBOSE;
+        OneSignal.Initialize(appId);
+
+        builder.Services.AddSingleton(new AppConfig(appId));
+        builder.Services.AddSingleton<MainPage>();
+        builder.Services.AddSingleton<App>();
+
+        return builder.Build();
+    }
+}
+
+public sealed record AppConfig(string OneSignalAppId);

--- a/examples/demo-no-location/MauiProgram.cs
+++ b/examples/demo-no-location/MauiProgram.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Maui;
 using OneSignalSDK.DotNet;
 using OsLogLevel = OneSignalSDK.DotNet.Core.Debug.LogLevel;
 
@@ -11,7 +12,7 @@ public static class MauiProgram
     {
         var builder = MauiApp.CreateBuilder();
 
-        builder.UseMauiApp<App>();
+        builder.UseMauiApp<App>().UseMauiCommunityToolkit();
 
         DotEnv.Load();
 

--- a/examples/demo-no-location/Platforms/Android/AndroidManifest.xml
+++ b/examples/demo-no-location/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.onesignal.example"
+>
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <uses-permission android:name="android.permission.VIBRATE" />
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
+  <application
+    android:allowBackup="true"
+    android:supportsRtl="true"
+  ></application>
+</manifest>

--- a/examples/demo-no-location/Platforms/Android/AndroidManifest.xml
+++ b/examples/demo-no-location/Platforms/Android/AndroidManifest.xml
@@ -9,8 +9,5 @@
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
-  <application
-    android:allowBackup="true"
-    android:supportsRtl="true"
-  ></application>
+  <application android:allowBackup="true" android:supportsRtl="true"></application>
 </manifest>

--- a/examples/demo-no-location/Platforms/Android/MainActivity.cs
+++ b/examples/demo-no-location/Platforms/Android/MainActivity.cs
@@ -1,0 +1,17 @@
+using Android.App;
+using Android.Content.PM;
+using Microsoft.Maui;
+
+namespace OneSignalDemoNoLocation;
+
+[Activity(
+    Theme = "@style/Maui.SplashTheme",
+    MainLauncher = true,
+    ConfigurationChanges = ConfigChanges.ScreenSize
+        | ConfigChanges.Orientation
+        | ConfigChanges.UiMode
+        | ConfigChanges.ScreenLayout
+        | ConfigChanges.SmallestScreenSize
+        | ConfigChanges.Density
+)]
+public class MainActivity : MauiAppCompatActivity { }

--- a/examples/demo-no-location/Platforms/Android/MainApplication.cs
+++ b/examples/demo-no-location/Platforms/Android/MainApplication.cs
@@ -1,0 +1,15 @@
+using Android.App;
+using Android.Runtime;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace OneSignalDemoNoLocation;
+
+[Application]
+public class MainApplication : MauiApplication
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership) { }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/examples/demo-no-location/Platforms/iOS/AppDelegate.cs
+++ b/examples/demo-no-location/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,11 @@
+using Foundation;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace OneSignalDemoNoLocation;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/examples/demo-no-location/Platforms/iOS/Entitlements.plist
+++ b/examples/demo-no-location/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/examples/demo-no-location/Platforms/iOS/Info.plist
+++ b/examples/demo-no-location/Platforms/iOS/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>OneSignal No-Location Demo</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.onesignal.example</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>remote-notification</string>
+    </array>
+</dict>
+</plist>

--- a/examples/demo-no-location/Platforms/iOS/Program.cs
+++ b/examples/demo-no-location/Platforms/iOS/Program.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace OneSignalDemoNoLocation;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/examples/demo-no-location/README.md
+++ b/examples/demo-no-location/README.md
@@ -1,0 +1,24 @@
+# OneSignal No-Location Demo
+
+This lightweight MAUI example uses the package id `com.onesignal.example` on iOS and Android, enables APNs for iOS, and builds with the native OneSignal location module disabled.
+
+Copy `.env.example` to `.env` and set your OneSignal app ID:
+
+```sh
+cp .env.example .env
+```
+
+Then run from this directory:
+
+```sh
+dotnet build -f net10.0-ios -t:Run
+dotnet build -f net10.0-android -t:Run
+```
+
+The project disables location with:
+
+```xml
+<OneSignalDisableLocation>true</OneSignalDisableLocation>
+```
+
+The app initializes OneSignal, requests notification permission only when you tap the button, sends a test push to the current push subscription, and includes a location test button that exercises the no-location path.

--- a/examples/demo-no-location/README.md
+++ b/examples/demo-no-location/README.md
@@ -21,4 +21,11 @@ The project disables location with:
 <OneSignalDisableLocation>true</OneSignalDisableLocation>
 ```
 
+`run-ios.sh` clears stale local iOS outputs if an old app bundle still contains or links `OneSignalLocation.framework`. If you run from an IDE and still see stale simulator state, clear local outputs once and reinstall the simulator app:
+
+```sh
+rm -rf bin obj
+xcrun simctl uninstall booted com.onesignal.example
+```
+
 The app initializes OneSignal, requests notification permission only when you tap the button, sends a test push to the current push subscription, and includes a location test button that exercises the no-location path.

--- a/examples/demo-no-location/README.md
+++ b/examples/demo-no-location/README.md
@@ -2,7 +2,7 @@
 
 This lightweight MAUI example uses the package id `com.onesignal.example` on iOS and Android, enables APNs for iOS, and builds with the native OneSignal location module disabled.
 
-Copy `.env.example` to `.env` and set your OneSignal app ID:
+The real `.env` file is intentionally gitignored. Copy `.env.example` to `.env` and set your OneSignal app ID:
 
 ```sh
 cp .env.example .env

--- a/examples/demo-no-location/README.md
+++ b/examples/demo-no-location/README.md
@@ -11,8 +11,8 @@ cp .env.example .env
 Then run from this directory:
 
 ```sh
-dotnet build -f net10.0-ios -t:Run
-dotnet build -f net10.0-android -t:Run
+./run-ios.sh
+./run-android.sh
 ```
 
 The project disables location with:

--- a/examples/demo-no-location/Resources/Styles/Colors.xaml
+++ b/examples/demo-no-location/Resources/Styles/Colors.xaml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+>
+  <Color x:Key="OsPrimary">#E54B4D</Color>
+  <Color x:Key="OsGrey700">#616161</Color>
+  <Color x:Key="OsGrey600">#757575</Color>
+  <Color x:Key="OsGrey400">#BDBDBD</Color>
+  <Color x:Key="OsLightBackground">#F8F9FA</Color>
+  <Color x:Key="OsCardBackground">#FFFFFF</Color>
+  <Color x:Key="OsCardBorder">#1A000000</Color>
+  <Color x:Key="OsDivider">#E8EAED</Color>
+</ResourceDictionary>

--- a/examples/demo-no-location/Resources/Styles/Colors.xaml
+++ b/examples/demo-no-location/Resources/Styles/Colors.xaml
@@ -4,6 +4,8 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 >
   <Color x:Key="OsPrimary">#E54B4D</Color>
+  <Color x:Key="OsPrimaryPressed">#C33F41</Color>
+  <Color x:Key="OsPrimaryTint">#1AE54B4D</Color>
   <Color x:Key="OsGrey700">#616161</Color>
   <Color x:Key="OsGrey600">#757575</Color>
   <Color x:Key="OsGrey400">#BDBDBD</Color>

--- a/examples/demo-no-location/Resources/Styles/Styles.xaml
+++ b/examples/demo-no-location/Resources/Styles/Styles.xaml
@@ -42,6 +42,24 @@
     <Setter Property="FontAttributes" Value="Bold" />
     <Setter Property="HeightRequest" Value="48" />
     <Setter Property="HorizontalOptions" Value="Fill" />
+    <Setter Property="VisualStateManager.VisualStateGroups">
+      <VisualStateGroupList>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Normal" />
+          <VisualState x:Name="Pressed">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{StaticResource OsPrimaryPressed}" />
+            </VisualState.Setters>
+          </VisualState>
+          <VisualState x:Name="Disabled">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{StaticResource OsGrey400}" />
+              <Setter Property="TextColor" Value="White" />
+            </VisualState.Setters>
+          </VisualState>
+        </VisualStateGroup>
+      </VisualStateGroupList>
+    </Setter>
   </Style>
 
   <Style TargetType="Button" x:Key="OutlineButtonStyle">
@@ -53,5 +71,26 @@
     <Setter Property="FontAttributes" Value="Bold" />
     <Setter Property="HeightRequest" Value="48" />
     <Setter Property="HorizontalOptions" Value="Fill" />
+    <Setter Property="VisualStateManager.VisualStateGroups">
+      <VisualStateGroupList>
+        <VisualStateGroup x:Name="CommonStates">
+          <VisualState x:Name="Normal" />
+          <VisualState x:Name="Pressed">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{StaticResource OsPrimaryTint}" />
+              <Setter Property="TextColor" Value="{StaticResource OsPrimaryPressed}" />
+              <Setter Property="BorderColor" Value="{StaticResource OsPrimaryPressed}" />
+            </VisualState.Setters>
+          </VisualState>
+          <VisualState x:Name="Disabled">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="Transparent" />
+              <Setter Property="TextColor" Value="{StaticResource OsGrey400}" />
+              <Setter Property="BorderColor" Value="{StaticResource OsGrey400}" />
+            </VisualState.Setters>
+          </VisualState>
+        </VisualStateGroup>
+      </VisualStateGroupList>
+    </Setter>
   </Style>
 </ResourceDictionary>

--- a/examples/demo-no-location/Resources/Styles/Styles.xaml
+++ b/examples/demo-no-location/Resources/Styles/Styles.xaml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ResourceDictionary
+  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+>
+  <Style TargetType="Border" x:Key="CardBorderStyle">
+    <Setter Property="Background" Value="{StaticResource OsCardBackground}" />
+    <Setter Property="StrokeShape" Value="RoundRectangle 12" />
+    <Setter Property="Stroke" Value="{StaticResource OsCardBorder}" />
+    <Setter Property="StrokeThickness" Value="2" />
+  </Style>
+
+  <Style TargetType="Label" x:Key="SectionHeaderStyle">
+    <Setter Property="FontAttributes" Value="Bold" />
+    <Setter Property="TextColor" Value="{StaticResource OsGrey700}" />
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="CharacterSpacing" Value="0.5" />
+  </Style>
+
+  <Style TargetType="Label" x:Key="LabelStyle">
+    <Setter Property="TextColor" Value="{StaticResource OsGrey600}" />
+    <Setter Property="FontSize" Value="14" />
+  </Style>
+
+  <Style TargetType="Label" x:Key="ValueStyle">
+    <Setter Property="TextColor" Value="{StaticResource OsGrey700}" />
+    <Setter Property="FontSize" Value="12" />
+    <Setter Property="FontFamily" Value="monospace" />
+    <Setter Property="HorizontalTextAlignment" Value="End" />
+    <Setter Property="LineBreakMode" Value="TailTruncation" />
+  </Style>
+
+  <Style TargetType="Label" x:Key="BodyStyle">
+    <Setter Property="TextColor" Value="{StaticResource OsGrey700}" />
+    <Setter Property="FontSize" Value="16" />
+  </Style>
+
+  <Style TargetType="Button" x:Key="PrimaryButtonStyle">
+    <Setter Property="BackgroundColor" Value="{StaticResource OsPrimary}" />
+    <Setter Property="TextColor" Value="White" />
+    <Setter Property="CornerRadius" Value="8" />
+    <Setter Property="FontAttributes" Value="Bold" />
+    <Setter Property="HeightRequest" Value="48" />
+    <Setter Property="HorizontalOptions" Value="Fill" />
+  </Style>
+
+  <Style TargetType="Button" x:Key="OutlineButtonStyle">
+    <Setter Property="BackgroundColor" Value="Transparent" />
+    <Setter Property="TextColor" Value="{StaticResource OsPrimary}" />
+    <Setter Property="BorderColor" Value="{StaticResource OsPrimary}" />
+    <Setter Property="BorderWidth" Value="1" />
+    <Setter Property="CornerRadius" Value="8" />
+    <Setter Property="FontAttributes" Value="Bold" />
+    <Setter Property="HeightRequest" Value="48" />
+    <Setter Property="HorizontalOptions" Value="Fill" />
+  </Style>
+</ResourceDictionary>

--- a/examples/demo-no-location/demo-no-location.csproj
+++ b/examples/demo-no-location/demo-no-location.csproj
@@ -1,0 +1,58 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))"
+      >$(TargetFrameworks);net10.0-ios</TargetFrameworks
+    >
+    <OutputType>Exe</OutputType>
+    <RootNamespace>OneSignalDemoNoLocation</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <ApplicationTitle>OneSignal No-Location Demo</ApplicationTitle>
+    <ApplicationId>com.onesignal.example</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+
+    <OneSignalDisableLocation>true</OneSignalDisableLocation>
+
+    <SupportedOSPlatformVersion
+      Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'"
+      >14.2</SupportedOSPlatformVersion
+    >
+    <SupportedOSPlatformVersion
+      Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'"
+      >26.0</SupportedOSPlatformVersion
+    >
+  </PropertyGroup>
+
+  <ItemGroup>
+    <MauiAsset Include=".env" Condition="Exists('.env')" LogicalName="appenv" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\OneSignalSDK.DotNet\OneSignalSDK.DotNet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
+    <GoogleServicesJson
+      Include="Platforms\Android\google-services.json"
+      Condition="Exists('Platforms\Android\google-services.json')"
+    />
+  </ItemGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+    <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios')) AND '$(RuntimeIdentifier)' != '' AND !$(RuntimeIdentifier.StartsWith('iossimulator'))">
+    <CodesignTeamId>99SW8E36CT</CodesignTeamId>
+    <CodesignProvision>Appium Demo - Main</CodesignProvision>
+  </PropertyGroup>
+</Project>

--- a/examples/demo-no-location/demo-no-location.csproj
+++ b/examples/demo-no-location/demo-no-location.csproj
@@ -2,8 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0-android</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))"
-      >$(TargetFrameworks);net10.0-ios</TargetFrameworks
-    >
+      >$(TargetFrameworks);net10.0-ios</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>OneSignalDemoNoLocation</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -20,12 +19,10 @@
 
     <SupportedOSPlatformVersion
       Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'"
-      >14.2</SupportedOSPlatformVersion
-    >
+      >14.2</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion
       Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'"
-      >26.0</SupportedOSPlatformVersion
-    >
+      >26.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -56,5 +53,4 @@
     <CodesignTeamId>99SW8E36CT</CodesignTeamId>
     <CodesignProvision>Appium Demo - Main</CodesignProvision>
   </PropertyGroup>
-
 </Project>

--- a/examples/demo-no-location/demo-no-location.csproj
+++ b/examples/demo-no-location/demo-no-location.csproj
@@ -37,6 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Maui" Version="14.0.0" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
   </ItemGroup>
 

--- a/examples/demo-no-location/demo-no-location.csproj
+++ b/examples/demo-no-location/demo-no-location.csproj
@@ -56,4 +56,5 @@
     <CodesignTeamId>99SW8E36CT</CodesignTeamId>
     <CodesignProvision>Appium Demo - Main</CodesignProvision>
   </PropertyGroup>
+
 </Project>

--- a/examples/demo-no-location/run-android.sh
+++ b/examples/demo-no-location/run-android.sh
@@ -2,4 +2,4 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-"$SCRIPT_DIR/../run-android.sh" "$SCRIPT_DIR/demo-no-location.csproj"
+"$SCRIPT_DIR/../run-android.sh" "$SCRIPT_DIR/demo-no-location.csproj" -p:OneSignalDisableLocation=true

--- a/examples/demo-no-location/run-android.sh
+++ b/examples/demo-no-location/run-android.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/../run-android.sh" "$SCRIPT_DIR/demo-no-location.csproj"

--- a/examples/demo-no-location/run-ios.sh
+++ b/examples/demo-no-location/run-ios.sh
@@ -2,4 +2,17 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+for app_bundle in "$SCRIPT_DIR"/bin/Debug/net10.0-ios/iossimulator-*/demo-no-location.app; do
+  [ -d "$app_bundle" ] || continue
+
+  executable="$app_bundle/demo-no-location"
+  framework="$app_bundle/Frameworks/OneSignalLocation.framework"
+  if [ -d "$framework" ] || { [ -f "$executable" ] && otool -L "$executable" 2>/dev/null | grep -q "OneSignalLocation.framework"; }; then
+    echo "Removing stale iOS build output that references OneSignalLocation.framework..."
+    rm -rf "$SCRIPT_DIR/bin" "$SCRIPT_DIR/obj"
+    break
+  fi
+done
+
 "$SCRIPT_DIR/../run-ios.sh" "$SCRIPT_DIR/demo-no-location.csproj"

--- a/examples/demo-no-location/run-ios.sh
+++ b/examples/demo-no-location/run-ios.sh
@@ -15,4 +15,4 @@ for app_bundle in "$SCRIPT_DIR"/bin/Debug/net10.0-ios/iossimulator-*/demo-no-loc
   fi
 done
 
-"$SCRIPT_DIR/../run-ios.sh" "$SCRIPT_DIR/demo-no-location.csproj"
+"$SCRIPT_DIR/../run-ios.sh" "$SCRIPT_DIR/demo-no-location.csproj" -p:OneSignalDisableLocation=true

--- a/examples/demo-no-location/run-ios.sh
+++ b/examples/demo-no-location/run-ios.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/../run-ios.sh" "$SCRIPT_DIR/demo-no-location.csproj"

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -71,11 +71,13 @@ dotnet build -f net10.0-ios -t:Run -p:RuntimeIdentifier=ios-arm64 -p:CodesignKey
 
 ## Configuration
 
-The app ships with a placeholder OneSignal App ID (`77e32082-ea27-42e3-a898-c72e141824ef`). To test with your own account, update the constant in `MauiProgram.cs` and rebuild:
+The real `.env` file is intentionally gitignored. Copy `.env.example` to `.env` and set your OneSignal app ID:
 
-```csharp
-private const string AppId = "<your-app-id>";
+```sh
+cp .env.example .env
 ```
+
+If `ONESIGNAL_APP_ID` is empty or still set to the placeholder, the app falls back to the default demo app ID in `MauiProgram.cs`.
 
 ## Troubleshooting
 

--- a/examples/demo/Resources/Styles/Colors.xaml
+++ b/examples/demo/Resources/Styles/Colors.xaml
@@ -4,6 +4,8 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 >
   <Color x:Key="OsPrimary">#E54B4D</Color>
+  <Color x:Key="OsPrimaryPressed">#C33F41</Color>
+  <Color x:Key="OsPrimaryTint">#1AE54B4D</Color>
   <Color x:Key="OsSuccess">#34A853</Color>
   <Color x:Key="OsGrey700">#616161</Color>
   <Color x:Key="OsGrey600">#757575</Color>

--- a/examples/demo/Resources/Styles/Styles.xaml
+++ b/examples/demo/Resources/Styles/Styles.xaml
@@ -22,6 +22,11 @@
       <VisualStateGroupList>
         <VisualStateGroup x:Name="CommonStates">
           <VisualState x:Name="Normal" />
+          <VisualState x:Name="Pressed">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{StaticResource OsPrimaryPressed}" />
+            </VisualState.Setters>
+          </VisualState>
           <VisualState x:Name="Disabled">
             <VisualState.Setters>
               <Setter Property="BackgroundColor" Value="{StaticResource OsGrey400}" />
@@ -46,6 +51,13 @@
       <VisualStateGroupList>
         <VisualStateGroup x:Name="CommonStates">
           <VisualState x:Name="Normal" />
+          <VisualState x:Name="Pressed">
+            <VisualState.Setters>
+              <Setter Property="BackgroundColor" Value="{StaticResource OsPrimaryTint}" />
+              <Setter Property="TextColor" Value="{StaticResource OsPrimaryPressed}" />
+              <Setter Property="BorderColor" Value="{StaticResource OsPrimaryPressed}" />
+            </VisualState.Setters>
+          </VisualState>
           <VisualState x:Name="Disabled">
             <VisualState.Setters>
               <Setter Property="BackgroundColor" Value="Transparent" />

--- a/examples/demo/run-android.sh
+++ b/examples/demo/run-android.sh
@@ -2,40 +2,4 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-serials=$(adb devices | awk '/\tdevice$/{print $1}')
-
-if [ -z "$serials" ]; then
-  echo "No Android devices connected. Start an emulator and try again."
-  exit 1
-fi
-
-labels=()
-devices=()
-while IFS= read -r serial; do
-  avd=$(adb -s "$serial" emu avd name 2>/dev/null | head -1 | tr -d '\r')
-  label="${avd:-$serial} ($serial)"
-  labels+=("$label")
-  devices+=("$serial")
-done <<< "$serials"
-
-if [ ${#devices[@]} -eq 1 ]; then
-  selected="${devices[0]}"
-  echo "Using device: ${labels[0]}"
-else
-  echo "Select a device:"
-  for i in "${!labels[@]}"; do
-    echo "  $((i+1))) ${labels[$i]}"
-  done
-  printf "Choice [1]: "
-  read -r choice
-  choice=${choice:-1}
-  idx=$((choice - 1))
-  if [ "$idx" -lt 0 ] || [ "$idx" -ge ${#devices[@]} ]; then
-    echo "Invalid choice."
-    exit 1
-  fi
-  selected="${devices[$idx]}"
-fi
-
-dotnet build "$SCRIPT_DIR/demo.csproj" -f net10.0-android -t:Run -p:AdbTarget="-s $selected"
+"$SCRIPT_DIR/../run-android.sh" "$SCRIPT_DIR/demo.csproj"

--- a/examples/demo/run-ios.sh
+++ b/examples/demo/run-ios.sh
@@ -2,45 +2,4 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-
-booted=$(xcrun simctl list devices booted -j | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-for devices in data['devices'].values():
-    for d in devices:
-        if d['state'] == 'Booted' and d.get('udid'):
-            print(d['udid'] + '|' + d['name'])
-")
-
-if [ -z "$booted" ]; then
-  echo "No booted iOS simulators found. Start a simulator and try again."
-  exit 1
-fi
-
-udids=()
-labels=()
-while IFS='|' read -r udid name; do
-  udids+=("$udid")
-  labels+=("$name ($udid)")
-done <<< "$booted"
-
-if [ ${#udids[@]} -eq 1 ]; then
-  selected="${udids[0]}"
-  echo "Using simulator: ${labels[0]}"
-else
-  echo "Select a simulator:"
-  for i in "${!labels[@]}"; do
-    echo "  $((i+1))) ${labels[$i]}"
-  done
-  printf "Choice [1]: "
-  read -r choice
-  choice=${choice:-1}
-  idx=$((choice - 1))
-  if [ "$idx" -lt 0 ] || [ "$idx" -ge ${#udids[@]} ]; then
-    echo "Invalid choice."
-    exit 1
-  fi
-  selected="${udids[$idx]}"
-fi
-
-dotnet build "$SCRIPT_DIR/demo.csproj" -f net10.0-ios -t:Build,Run -p:_DeviceName=":v2:udid=$selected"
+"$SCRIPT_DIR/../run-ios.sh" "$SCRIPT_DIR/demo.csproj"

--- a/examples/run-android.sh
+++ b/examples/run-android.sh
@@ -2,6 +2,7 @@
 set -e
 
 PROJECT_FILE="$1"
+shift || true
 
 if [ -z "$PROJECT_FILE" ]; then
   echo "Usage: $0 <project-file>"
@@ -43,4 +44,4 @@ else
   selected="${devices[$idx]}"
 fi
 
-dotnet build "$PROJECT_FILE" -f net10.0-android -t:Run -p:AdbTarget="-s $selected"
+dotnet build "$PROJECT_FILE" -f net10.0-android -t:Run -p:AdbTarget="-s $selected" "$@"

--- a/examples/run-android.sh
+++ b/examples/run-android.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+PROJECT_FILE="$1"
+
+if [ -z "$PROJECT_FILE" ]; then
+  echo "Usage: $0 <project-file>"
+  exit 1
+fi
+
+serials=$(adb devices | awk '/\tdevice$/{print $1}')
+
+if [ -z "$serials" ]; then
+  echo "No Android devices connected. Start an emulator and try again."
+  exit 1
+fi
+
+labels=()
+devices=()
+while IFS= read -r serial; do
+  avd=$(adb -s "$serial" emu avd name 2>/dev/null | head -1 | tr -d '\r')
+  label="${avd:-$serial} ($serial)"
+  labels+=("$label")
+  devices+=("$serial")
+done <<< "$serials"
+
+if [ ${#devices[@]} -eq 1 ]; then
+  selected="${devices[0]}"
+  echo "Using device: ${labels[0]}"
+else
+  echo "Select a device:"
+  for i in "${!labels[@]}"; do
+    echo "  $((i+1))) ${labels[$i]}"
+  done
+  printf "Choice [1]: "
+  read -r choice
+  choice=${choice:-1}
+  idx=$((choice - 1))
+  if [ "$idx" -lt 0 ] || [ "$idx" -ge ${#devices[@]} ]; then
+    echo "Invalid choice."
+    exit 1
+  fi
+  selected="${devices[$idx]}"
+fi
+
+dotnet build "$PROJECT_FILE" -f net10.0-android -t:Run -p:AdbTarget="-s $selected"

--- a/examples/run-ios.sh
+++ b/examples/run-ios.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+PROJECT_FILE="$1"
+
+if [ -z "$PROJECT_FILE" ]; then
+  echo "Usage: $0 <project-file>"
+  exit 1
+fi
+
+booted=$(xcrun simctl list devices booted -j | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for devices in data['devices'].values():
+    for d in devices:
+        if d['state'] == 'Booted' and d.get('udid'):
+            print(d['udid'] + '|' + d['name'])
+")
+
+if [ -z "$booted" ]; then
+  echo "No booted iOS simulators found. Start a simulator and try again."
+  exit 1
+fi
+
+udids=()
+labels=()
+while IFS='|' read -r udid name; do
+  udids+=("$udid")
+  labels+=("$name ($udid)")
+done <<< "$booted"
+
+if [ ${#udids[@]} -eq 1 ]; then
+  selected="${udids[0]}"
+  echo "Using simulator: ${labels[0]}"
+else
+  echo "Select a simulator:"
+  for i in "${!labels[@]}"; do
+    echo "  $((i+1))) ${labels[$i]}"
+  done
+  printf "Choice [1]: "
+  read -r choice
+  choice=${choice:-1}
+  idx=$((choice - 1))
+  if [ "$idx" -lt 0 ] || [ "$idx" -ge ${#udids[@]} ]; then
+    echo "Invalid choice."
+    exit 1
+  fi
+  selected="${udids[$idx]}"
+fi
+
+dotnet build "$PROJECT_FILE" -f net10.0-ios -t:Build,Run -p:_DeviceName=":v2:udid=$selected"

--- a/examples/run-ios.sh
+++ b/examples/run-ios.sh
@@ -2,6 +2,7 @@
 set -e
 
 PROJECT_FILE="$1"
+shift || true
 
 if [ -z "$PROJECT_FILE" ]; then
   echo "Usage: $0 <project-file>"
@@ -48,4 +49,4 @@ else
   selected="${udids[$idx]}"
 fi
 
-dotnet build "$PROJECT_FILE" -f net10.0-ios -t:Build,Run -p:_DeviceName=":v2:udid=$selected"
+dotnet build "$PROJECT_FILE" -f net10.0-ios -t:Build,Run -p:_DeviceName=":v2:udid=$selected" "$@"


### PR DESCRIPTION
# Description
## One Line Summary
Adds an MSBuild-controlled way to exclude the native OneSignal location module and includes a no-location MAUI demo.


Expect in Console.app:
<img width="1134" height="192" alt="Screenshot 2026-06-25 at 3 07 00 PM" src="https://github.com/user-attachments/assets/8cadca28-8442-412a-a2de-062804b7199a" />

Expect in ADB/LogCat:
<img width="1441" height="361" alt="Screenshot 2026-06-25 at 3 20 45 PM" src="https://github.com/user-attachments/assets/c14662c0-4f6c-4e2b-8844-d1498fb0be40" />

Demo app:
<img width="493" height="978" alt="Screenshot 2026-06-26 at 10 32 06 AM" src="https://github.com/user-attachments/assets/f23b49e2-55a1-4eb3-b398-f9f28397a729" />

## Details

### Motivation
Apps that do not use OneSignal location features should be able to omit native location dependencies while keeping notification, user, IAM, outcome, and live activity behavior available.

### Scope
This introduces `<OneSignalDisableLocation>true</OneSignalDisableLocation>` for source/package builds, conditionally excludes iOS and Android location native assets, and makes location API calls gracefully no-op when the native module is absent. It also adds `examples/demo-no-location` with APNs capability and updates demo scripts/styles shared by the examples.

# Testing
## Unit testing
No unit tests were added; this change primarily affects MSBuild item inclusion and native app packaging paths.

## Manual testing
From `examples/demo-no-location`:

- **Android:** Ran `./run-android.sh` on an emulator, tapped **TEST LOCATION REQUEST**, and confirmed in Logcat that the location module was excluded (missing-module error, no location dependency linked).
- **iOS:** Ran `./run-ios.sh` on a simulator, tapped **TEST LOCATION REQUEST**, and confirmed in Console that the location module was missing (missing-module error, no `OneSignalLocation.framework` in the app).

# Affected code checklist
   - [x] Notifications
      - [ ] Display
      - [ ] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)