### PR TITLE
chore: [SDK-4788] add local notification compatibility demo

### DIFF
--- a/examples/plugin-local-notif/.env.example
+++ b/examples/plugin-local-notif/.env.example
@@ -1,0 +1,2 @@
+# Default App ID (used when ONESIGNAL_APP_ID is empty or missing): 77e32082-ea27-42e3-a898-c72e141824ef
+ONESIGNAL_APP_ID=your-onesignal-app-id

--- a/examples/plugin-local-notif/App.cs
+++ b/examples/plugin-local-notif/App.cs
@@ -1,0 +1,12 @@
+namespace PluginLocalNotifDemo;
+
+public class App : Application
+{
+    protected override Window CreateWindow(IActivationState? activationState)
+    {
+        return new Window(new NavigationPage(new MainPage()))
+        {
+            Title = "OneSignal LocalNotification Repro",
+        };
+    }
+}

--- a/examples/plugin-local-notif/DotEnv.cs
+++ b/examples/plugin-local-notif/DotEnv.cs
@@ -1,0 +1,57 @@
+namespace PluginLocalNotifDemo;
+
+public static class DotEnv
+{
+    private static readonly Dictionary<string, string> Values = new();
+    private static bool _loaded;
+
+    public static void Load()
+    {
+        if (_loaded)
+            return;
+
+        try
+        {
+            using var stream = Task.Run(() => FileSystem.OpenAppPackageFileAsync("appenv"))
+                .GetAwaiter()
+                .GetResult();
+            using var reader = new StreamReader(stream);
+
+            foreach (
+                var line in reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            )
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith('#') || !trimmed.Contains('='))
+                    continue;
+
+                var eqIndex = trimmed.IndexOf('=');
+                var key = trimmed[..eqIndex].Trim();
+                var value = trimmed[(eqIndex + 1)..].Trim();
+
+                if (
+                    value.Length >= 2
+                    && (
+                        (value[0] == '"' && value[^1] == '"')
+                        || (value[0] == '\'' && value[^1] == '\'')
+                    )
+                )
+                {
+                    value = value[1..^1];
+                }
+
+                Values[key] = value;
+            }
+        }
+        catch
+        {
+            // Missing .env is expected for first-time demo setup.
+        }
+        finally
+        {
+            _loaded = true;
+        }
+    }
+
+    public static string Get(string key) => Values.TryGetValue(key, out var value) ? value : "";
+}

--- a/examples/plugin-local-notif/MainPage.cs
+++ b/examples/plugin-local-notif/MainPage.cs
@@ -1,0 +1,136 @@
+using OneSignalSDK.DotNet;
+using Plugin.LocalNotification;
+using Plugin.LocalNotification.Core.Models;
+
+namespace PluginLocalNotifDemo;
+
+public class MainPage : ContentPage
+{
+    private int _nextNotificationId = 132;
+    private readonly Label _statusLabel;
+    private readonly Label _permissionLabel;
+
+    public MainPage()
+    {
+        Title = "Local Notification Repro";
+        BackgroundColor = Colors.White;
+
+        _statusLabel = new Label
+        {
+            Text = "Ready. Request permissions, then show a local notification.",
+            TextColor = Colors.Black,
+        };
+
+        _permissionLabel = new Label { TextColor = Colors.DimGray };
+
+        var requestOneSignalPermissionButton = new Button
+        {
+            Text = "Request OneSignal Permission",
+            AutomationId = "request_onesignal_permission_button",
+        };
+        requestOneSignalPermissionButton.Clicked += async (s, e) =>
+        {
+            var granted = await OneSignal.Notifications.RequestPermissionAsync(true);
+            SetStatus($"OneSignal permission granted: {granted}");
+            RefreshPermissionLabel();
+        };
+
+        var requestLocalPermissionButton = new Button
+        {
+            Text = "Request LocalNotification Permission",
+            AutomationId = "request_local_notification_permission_button",
+        };
+        requestLocalPermissionButton.Clicked += async (s, e) =>
+        {
+            var granted = await LocalNotificationCenter.Current.RequestNotificationPermission();
+            SetStatus($"LocalNotification permission granted: {granted}");
+            RefreshPermissionLabel();
+        };
+
+        var showLocalNotificationButton = new Button
+        {
+            Text = "Show Local Notification",
+            AutomationId = "show_local_notification_button",
+        };
+        showLocalNotificationButton.Clicked += async (s, e) =>
+        {
+            var request = new NotificationRequest
+            {
+                NotificationId = _nextNotificationId++,
+                Title = "Local notification repro",
+                Description = "Foreground display/tap exercises the iOS notification delegate path.",
+            };
+
+            await LocalNotificationCenter.Current.Show(request);
+            SetStatus(
+                "Local notification requested. If it is delivered while foregrounded or tapped "
+                    + "from Notification Center, watch for the selector crash from issue #132."
+            );
+        };
+
+        var clearButton = new Button
+        {
+            Text = "Clear Delivered Notifications",
+            AutomationId = "clear_notifications_button",
+        };
+        clearButton.Clicked += (s, e) =>
+        {
+            OneSignal.Notifications.ClearAllNotifications();
+            SetStatus("Cleared delivered notifications through OneSignal.");
+        };
+
+        Content = new ScrollView
+        {
+            Content = new VerticalStackLayout
+            {
+                Padding = 20,
+                Spacing = 16,
+                Children =
+                {
+                    new Label
+                    {
+                        Text = "OneSignal + Plugin.LocalNotification",
+                        FontSize = 24,
+                        FontAttributes = FontAttributes.Bold,
+                        TextColor = Colors.Black,
+                    },
+                    new Label
+                    {
+                        Text =
+                            "Minimal iOS repro for GitHub issue #132. The interesting paths are "
+                            + "foreground delivery and tapping the delivered local notification.",
+                        TextColor = Colors.DimGray,
+                    },
+                    _permissionLabel,
+                    requestOneSignalPermissionButton,
+                    requestLocalPermissionButton,
+                    showLocalNotificationButton,
+                    clearButton,
+                    _statusLabel,
+                },
+            },
+        };
+
+        RefreshPermissionLabel();
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        RefreshPermissionLabel();
+    }
+
+    private void RefreshPermissionLabel()
+    {
+        _permissionLabel.Text = $"OneSignal permission: {OneSignal.Notifications.Permission}";
+    }
+
+    private void SetStatus(string message)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            _statusLabel.Text = message;
+            System.Diagnostics.Debug.WriteLine(message);
+        });
+    }
+}

--- a/examples/plugin-local-notif/MainPage.cs
+++ b/examples/plugin-local-notif/MainPage.cs
@@ -73,7 +73,8 @@ public class MainPage : ContentPage
             {
                 NotificationId = _nextNotificationId++,
                 Title = "Local notification repro",
-                Description = "Foreground display/tap exercises the iOS notification delegate path.",
+                Description =
+                    "Foreground display/tap exercises the iOS notification delegate path.",
                 Android = new AndroidOptions
                 {
                     IconSmallName = new AndroidIcon("ic_stat_local_notification", "drawable"),

--- a/examples/plugin-local-notif/MainPage.cs
+++ b/examples/plugin-local-notif/MainPage.cs
@@ -1,5 +1,6 @@
 using OneSignalSDK.DotNet;
 using Plugin.LocalNotification;
+using Plugin.LocalNotification.Core.Models.AndroidOption;
 using Plugin.LocalNotification.Core.Models;
 
 namespace PluginLocalNotifDemo;
@@ -59,6 +60,10 @@ public class MainPage : ContentPage
                 NotificationId = _nextNotificationId++,
                 Title = "Local notification repro",
                 Description = "Foreground display/tap exercises the iOS notification delegate path.",
+                Android = new AndroidOptions
+                {
+                    IconSmallName = new AndroidIcon("ic_stat_local_notification", "drawable"),
+                },
             };
 
             await LocalNotificationCenter.Current.Show(request);

--- a/examples/plugin-local-notif/MainPage.cs
+++ b/examples/plugin-local-notif/MainPage.cs
@@ -1,7 +1,10 @@
 using OneSignalSDK.DotNet;
+using OneSignalSDK.DotNet.Core.Notifications;
+using OneSignalSDK.DotNet.Core.User;
+using OneSignalSDK.DotNet.Core.User.Subscriptions;
 using Plugin.LocalNotification;
-using Plugin.LocalNotification.Core.Models.AndroidOption;
 using Plugin.LocalNotification.Core.Models;
+using Plugin.LocalNotification.Core.Models.AndroidOption;
 
 namespace PluginLocalNotifDemo;
 
@@ -10,6 +13,7 @@ public class MainPage : ContentPage
     private int _nextNotificationId = 132;
     private readonly Label _statusLabel;
     private readonly Label _permissionLabel;
+    private readonly Label _pushInfoLabel;
 
     public MainPage()
     {
@@ -23,6 +27,15 @@ public class MainPage : ContentPage
         };
 
         _permissionLabel = new Label { TextColor = Colors.DimGray };
+        _pushInfoLabel = new Label
+        {
+            TextColor = Colors.DimGray,
+            LineBreakMode = LineBreakMode.WordWrap,
+        };
+
+        OneSignal.Notifications.PermissionChanged += OnPermissionChanged;
+        OneSignal.User.PushSubscription.Changed += OnPushSubscriptionChanged;
+        OneSignal.User.Changed += OnUserChanged;
 
         var requestOneSignalPermissionButton = new Button
         {
@@ -34,6 +47,7 @@ public class MainPage : ContentPage
             var granted = await OneSignal.Notifications.RequestPermissionAsync(true);
             SetStatus($"OneSignal permission granted: {granted}");
             RefreshPermissionLabel();
+            RefreshPushInfoLabel();
         };
 
         var requestLocalPermissionButton = new Button
@@ -84,6 +98,13 @@ public class MainPage : ContentPage
             SetStatus("Cleared delivered notifications through OneSignal.");
         };
 
+        var refreshPushInfoButton = new Button
+        {
+            Text = "Refresh Push Info",
+            AutomationId = "refresh_push_info_button",
+        };
+        refreshPushInfoButton.Clicked += (s, e) => RefreshPushInfoLabel();
+
         Content = new ScrollView
         {
             Content = new VerticalStackLayout
@@ -107,27 +128,60 @@ public class MainPage : ContentPage
                         TextColor = Colors.DimGray,
                     },
                     _permissionLabel,
+                    _pushInfoLabel,
                     requestOneSignalPermissionButton,
                     requestLocalPermissionButton,
                     showLocalNotificationButton,
                     clearButton,
+                    refreshPushInfoButton,
                     _statusLabel,
                 },
             },
         };
 
         RefreshPermissionLabel();
+        RefreshPushInfoLabel();
     }
 
     protected override void OnAppearing()
     {
         base.OnAppearing();
         RefreshPermissionLabel();
+        RefreshPushInfoLabel();
     }
 
     private void RefreshPermissionLabel()
     {
         _permissionLabel.Text = $"OneSignal permission: {OneSignal.Notifications.Permission}";
+    }
+
+    private void RefreshPushInfoLabel()
+    {
+        var pushSubscription = OneSignal.User.PushSubscription;
+        _pushInfoLabel.Text =
+            $"OneSignal ID: {FormatValue(OneSignal.User.OneSignalId)}\n"
+            + $"Push subscription ID: {FormatValue(pushSubscription.Id)}\n"
+            + $"Push opted in: {pushSubscription.OptedIn}\n"
+            + $"Push token: {FormatValue(pushSubscription.Token)}";
+    }
+
+    private void OnPermissionChanged(object? sender, NotificationPermissionChangedEventArgs args)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            RefreshPermissionLabel();
+            RefreshPushInfoLabel();
+        });
+    }
+
+    private void OnPushSubscriptionChanged(object? sender, PushSubscriptionChangedEventArgs args)
+    {
+        MainThread.BeginInvokeOnMainThread(RefreshPushInfoLabel);
+    }
+
+    private void OnUserChanged(object? sender, UserStateChangedEventArgs args)
+    {
+        MainThread.BeginInvokeOnMainThread(RefreshPushInfoLabel);
     }
 
     private void SetStatus(string message)
@@ -138,4 +192,7 @@ public class MainPage : ContentPage
             System.Diagnostics.Debug.WriteLine(message);
         });
     }
+
+    private static string FormatValue(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "-" : value;
 }

--- a/examples/plugin-local-notif/MauiProgram.cs
+++ b/examples/plugin-local-notif/MauiProgram.cs
@@ -1,0 +1,29 @@
+using OneSignalSDK.DotNet;
+using Plugin.LocalNotification;
+using OsLogLevel = OneSignalSDK.DotNet.Core.Debug.LogLevel;
+
+namespace PluginLocalNotifDemo;
+
+public static class MauiProgram
+{
+    private const string OneSignalAppId = "77e32082-ea27-42e3-a898-c72e141824ef";
+
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+
+        builder.UseMauiApp<App>().UseLocalNotification();
+
+        var app = builder.Build();
+
+        OneSignal.Debug.LogLevel = OsLogLevel.VERBOSE;
+        OneSignal.Initialize(OneSignalAppId);
+
+        OneSignal.Notifications.WillDisplay += (s, e) =>
+            System.Diagnostics.Debug.WriteLine("OneSignal notification will display");
+        OneSignal.Notifications.Clicked += (s, e) =>
+            System.Diagnostics.Debug.WriteLine("OneSignal notification clicked");
+
+        return app;
+    }
+}

--- a/examples/plugin-local-notif/MauiProgram.cs
+++ b/examples/plugin-local-notif/MauiProgram.cs
@@ -6,7 +6,7 @@ namespace PluginLocalNotifDemo;
 
 public static class MauiProgram
 {
-    private const string OneSignalAppId = "77e32082-ea27-42e3-a898-c72e141824ef";
+    private const string DefaultAppId = "77e32082-ea27-42e3-a898-c72e141824ef";
 
     public static MauiApp CreateMauiApp()
     {
@@ -16,8 +16,16 @@ public static class MauiProgram
 
         var app = builder.Build();
 
+        DotEnv.Load();
+
+        var envAppId = DotEnv.Get("ONESIGNAL_APP_ID");
+        var appId =
+            string.IsNullOrWhiteSpace(envAppId) || envAppId == "your-onesignal-app-id"
+                ? DefaultAppId
+                : envAppId.Trim();
+
         OneSignal.Debug.LogLevel = OsLogLevel.VERBOSE;
-        OneSignal.Initialize(OneSignalAppId);
+        OneSignal.Initialize(appId);
 
         OneSignal.Notifications.WillDisplay += (s, e) =>
             System.Diagnostics.Debug.WriteLine("OneSignal notification will display");

--- a/examples/plugin-local-notif/Platforms/Android/AndroidManifest.xml
+++ b/examples/plugin-local-notif/Platforms/Android/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.onesignal.pluginlocalnotif"
+>
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+  <uses-permission android:name="android.permission.VIBRATE" />
+  <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+
+  <application android:allowBackup="true" android:supportsRtl="true"></application>
+</manifest>

--- a/examples/plugin-local-notif/Platforms/Android/AndroidManifest.xml
+++ b/examples/plugin-local-notif/Platforms/Android/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
   xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.onesignal.pluginlocalnotif"
+  package="com.onesignal.example"
 >
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/examples/plugin-local-notif/Platforms/Android/MainActivity.cs
+++ b/examples/plugin-local-notif/Platforms/Android/MainActivity.cs
@@ -1,0 +1,17 @@
+using Android.App;
+using Android.Content.PM;
+using Microsoft.Maui;
+
+namespace PluginLocalNotifDemo;
+
+[Activity(
+    Theme = "@style/Maui.SplashTheme",
+    MainLauncher = true,
+    ConfigurationChanges = ConfigChanges.ScreenSize
+        | ConfigChanges.Orientation
+        | ConfigChanges.UiMode
+        | ConfigChanges.ScreenLayout
+        | ConfigChanges.SmallestScreenSize
+        | ConfigChanges.Density
+)]
+public class MainActivity : MauiAppCompatActivity { }

--- a/examples/plugin-local-notif/Platforms/Android/MainApplication.cs
+++ b/examples/plugin-local-notif/Platforms/Android/MainApplication.cs
@@ -1,0 +1,15 @@
+using Android.App;
+using Android.Runtime;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace PluginLocalNotifDemo;
+
+[Application]
+public class MainApplication : MauiApplication
+{
+    public MainApplication(IntPtr handle, JniHandleOwnership ownership)
+        : base(handle, ownership) { }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/examples/plugin-local-notif/Platforms/Android/Resources/drawable/ic_stat_local_notification.xml
+++ b/examples/plugin-local-notif/Platforms/Android/Resources/drawable/ic_stat_local_notification.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  android:width="24dp"
+  android:height="24dp"
+  android:viewportWidth="24"
+  android:viewportHeight="24"
+>
+  <path
+    android:fillColor="#FFFFFFFF"
+    android:pathData="M12,22a2.5,2.5 0,0 0,2.5 -2.5h-5A2.5,2.5 0,0 0,12 22zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32V4a1.5,1.5 0,0 0,-3 0v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z"
+  />
+</vector>

--- a/examples/plugin-local-notif/Platforms/iOS/AppDelegate.cs
+++ b/examples/plugin-local-notif/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,11 @@
+using Foundation;
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+
+namespace PluginLocalNotifDemo;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/examples/plugin-local-notif/Platforms/iOS/Entitlements.plist
+++ b/examples/plugin-local-notif/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>aps-environment</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/examples/plugin-local-notif/Platforms/iOS/Info.plist
+++ b/examples/plugin-local-notif/Platforms/iOS/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>LocalNotification Repro</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.onesignal.pluginlocalnotif</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UIDeviceFamily</key>
+    <array>
+        <integer>1</integer>
+        <integer>2</integer>
+    </array>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UILaunchScreen</key>
+    <dict/>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>remote-notification</string>
+    </array>
+    <key>aps-environment</key>
+    <string>development</string>
+</dict>
+</plist>

--- a/examples/plugin-local-notif/Platforms/iOS/Info.plist
+++ b/examples/plugin-local-notif/Platforms/iOS/Info.plist
@@ -5,7 +5,7 @@
     <key>CFBundleDisplayName</key>
     <string>LocalNotification Repro</string>
     <key>CFBundleIdentifier</key>
-    <string>com.onesignal.pluginlocalnotif</string>
+    <string>com.onesignal.example</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
     <key>UIDeviceFamily</key>

--- a/examples/plugin-local-notif/Platforms/iOS/Program.cs
+++ b/examples/plugin-local-notif/Platforms/iOS/Program.cs
@@ -1,0 +1,11 @@
+using UIKit;
+
+namespace PluginLocalNotifDemo;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/examples/plugin-local-notif/README.md
+++ b/examples/plugin-local-notif/README.md
@@ -1,0 +1,60 @@
+# OneSignal + Plugin.LocalNotification Repro
+
+Minimal .NET MAUI iOS app for investigating
+[GitHub issue #132](https://github.com/OneSignal/OneSignal-DotNet-SDK/issues/132).
+
+## What This Reproduces
+
+Issue #132 reports an iOS crash when `OneSignalSDK.DotNet` and
+`Plugin.LocalNotification` are both installed:
+
+```text
+Cannot get the method descriptor for the selector
+'onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:'
+on the type 'Plugin.LocalNotification.Platforms.UserNotificationCenterDelegate'
+```
+
+Related issue #110 reported the same failure shape for the foreground delivery
+selector:
+
+```text
+onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:
+```
+
+Both failures point at the same interaction: OneSignal's native iOS SDK swizzles
+`UNUserNotificationCenterDelegate` methods, while `Plugin.LocalNotification`
+installs its own delegate that only implements the normal Apple selectors.
+
+## Run
+
+From this directory:
+
+```sh
+dotnet build -f net10.0-ios -t:Run
+```
+
+To target a specific simulator:
+
+```sh
+dotnet build -f net10.0-ios -t:Build,Run -p:_DeviceName=:v2:udid=<simulator-udid>
+```
+
+## Repro Steps
+
+1. Launch the app on iOS.
+2. Tap `Request OneSignal Permission`.
+3. Tap `Request LocalNotification Permission`.
+4. Tap `Show Local Notification` while the app is foregrounded.
+5. If the notification is delivered, tap it from Notification Center.
+6. Watch device logs for the `onesignalUserNotificationCenter:*` selector crash.
+
+The bundled app ID matches the main demo app's default ID. To test against a
+different OneSignal app, update `OneSignalAppId` in `MauiProgram.cs`.
+
+## Notes
+
+The native OneSignal iOS SDK now documents disabling swizzling via
+`OneSignal_disable_swizzling` and manually forwarding notification delegate
+methods. This .NET binding currently does not expose the newer manual forwarding
+APIs, so this sample keeps swizzling enabled and demonstrates the reported
+interaction directly.

--- a/examples/plugin-local-notif/README.md
+++ b/examples/plugin-local-notif/README.md
@@ -30,6 +30,7 @@ installs its own delegate that only implements the normal Apple selectors.
 From this directory, run iOS:
 
 ```sh
+cp .env.example .env
 ./run-ios.sh
 ```
 
@@ -51,8 +52,9 @@ devices.
 5. If the notification is delivered, tap it from Notification Center.
 6. Watch device logs for the `onesignalUserNotificationCenter:*` selector crash.
 
-The bundled app ID matches the main demo app's default ID. To test against a
-different OneSignal app, update `OneSignalAppId` in `MauiProgram.cs`.
+The bundled app ID matches the main demo app's default ID when
+`ONESIGNAL_APP_ID` is missing or still set to the placeholder. To test against a
+different OneSignal app, set `ONESIGNAL_APP_ID` in `.env`.
 
 ## Notes
 

--- a/examples/plugin-local-notif/README.md
+++ b/examples/plugin-local-notif/README.md
@@ -1,6 +1,6 @@
 # OneSignal + Plugin.LocalNotification Repro
 
-Minimal .NET MAUI iOS app for investigating
+Minimal .NET MAUI app for investigating the iOS interaction reported in
 [GitHub issue #132](https://github.com/OneSignal/OneSignal-DotNet-SDK/issues/132).
 
 ## What This Reproduces
@@ -27,17 +27,20 @@ installs its own delegate that only implements the normal Apple selectors.
 
 ## Run
 
-From this directory:
+From this directory, run iOS:
 
 ```sh
-dotnet build -f net10.0-ios -t:Run
+./run-ios.sh
 ```
 
-To target a specific simulator:
+Or run Android:
 
 ```sh
-dotnet build -f net10.0-ios -t:Build,Run -p:_DeviceName=:v2:udid=<simulator-udid>
+./run-android.sh
 ```
+
+The shared scripts select from currently booted simulators or connected Android
+devices.
 
 ## Repro Steps
 

--- a/examples/plugin-local-notif/plugin-local-notif.csproj
+++ b/examples/plugin-local-notif/plugin-local-notif.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-ios</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PluginLocalNotifDemo</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <ApplicationTitle>OneSignal LocalNotification Repro</ApplicationTitle>
+    <ApplicationId>com.onesignal.pluginlocalnotif</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
+    <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\OneSignalSDK.DotNet\OneSignalSDK.DotNet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.41" />
+    <PackageReference Include="Plugin.LocalNotification" Version="14.1.1" />
+  </ItemGroup>
+</Project>

--- a/examples/plugin-local-notif/plugin-local-notif.csproj
+++ b/examples/plugin-local-notif/plugin-local-notif.csproj
@@ -11,7 +11,7 @@
     <Nullable>enable</Nullable>
 
     <ApplicationTitle>OneSignal LocalNotification Repro</ApplicationTitle>
-    <ApplicationId>com.onesignal.pluginlocalnotif</ApplicationId>
+    <ApplicationId>com.onesignal.example</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <SupportedOSPlatformVersion

--- a/examples/plugin-local-notif/plugin-local-notif.csproj
+++ b/examples/plugin-local-notif/plugin-local-notif.csproj
@@ -22,6 +22,10 @@
       >26.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
+  <ItemGroup>
+    <MauiAsset Include=".env" Condition="Exists('.env')" LogicalName="appenv" />
+  </ItemGroup>
+
   <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
     <CodesignEntitlements>Platforms\iOS\Entitlements.plist</CodesignEntitlements>
   </PropertyGroup>

--- a/examples/plugin-local-notif/plugin-local-notif.csproj
+++ b/examples/plugin-local-notif/plugin-local-notif.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0-ios</TargetFramework>
+    <TargetFrameworks>net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('OSX'))"
+      >$(TargetFrameworks);net10.0-ios</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <RootNamespace>PluginLocalNotifDemo</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -12,7 +14,12 @@
     <ApplicationId>com.onesignal.pluginlocalnotif</ApplicationId>
     <ApplicationVersion>1</ApplicationVersion>
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
-    <SupportedOSPlatformVersion>15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion
+      Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'"
+      >15.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion
+      Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'"
+      >26.0</SupportedOSPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">

--- a/examples/plugin-local-notif/run-android.sh
+++ b/examples/plugin-local-notif/run-android.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/../run-android.sh" "$SCRIPT_DIR/plugin-local-notif.csproj"

--- a/examples/plugin-local-notif/run-ios.sh
+++ b/examples/plugin-local-notif/run-ios.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/../run-ios.sh" "$SCRIPT_DIR/plugin-local-notif.csproj"


### PR DESCRIPTION
# Description
## One Line Summary
Adds a .NET MAUI demo for reproducing and testing OneSignal with Plugin.LocalNotification.

## Details
### Motivation
Provide a focused reproduction for the iOS notification delegate crash reported in issues #110 and #132, while also covering Android compatibility.

### Scope
Adds the `examples/plugin-local-notif` app, iOS and Android platform setup, `.env` app ID configuration, run scripts, notification test controls, and push subscription diagnostics. This PR does not change SDK runtime behavior or public APIs.

# Testing
## Manual testing
- Built and launched the iOS simulator app using `run-ios.sh`.
- Verified local notification foreground display and notification permission flows.
- Built the Android target and verified local and OneSignal notification flows.

# Affected code checklist
- [x] Notifications
  - [x] Display
  - [x] Open
  - [ ] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [ ] Public API changes

# Checklist
## Overview
- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
- [x] Code is as readable as possible
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)