### PR TITLE
feat: [SDK-4788] prototype iOS notification delegate proxy

### DIFF
--- a/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
+++ b/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
@@ -8,6 +8,54 @@ using WebKit;
 
 namespace Com.OneSignal.iOS
 {
+    [BaseType(typeof(NSObject))]
+    interface OneSignalCoreHelper
+    {
+        [Static]
+        [Export("isOneSignalPayload:")]
+        bool IsOneSignalPayload(NSDictionary payload);
+    }
+
+    [Protocol]
+    [Model]
+    [BaseType(typeof(NSObject))]
+    interface OneSignalNotificationCenterDelegateProxy
+    {
+        [Abstract]
+        [Export("userNotificationCenter:willPresentNotification:withCompletionHandler:")]
+        void WillPresentNotification(
+            UNUserNotificationCenter center,
+            UNNotification notification,
+            Action<UNNotificationPresentationOptions> completionHandler
+        );
+
+        [Abstract]
+        [Export("onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:")]
+        void OneSignalWillPresentNotification(
+            UNUserNotificationCenter center,
+            UNNotification notification,
+            Action<UNNotificationPresentationOptions> completionHandler
+        );
+
+        [Abstract]
+        [Export("userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:")]
+        void DidReceiveNotificationResponse(
+            UNUserNotificationCenter center,
+            UNNotificationResponse response,
+            Action completionHandler
+        );
+
+        [Abstract]
+        [Export(
+            "onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:"
+        )]
+        void OneSignalDidReceiveNotificationResponse(
+            UNUserNotificationCenter center,
+            UNNotificationResponse response,
+            Action completionHandler
+        );
+    }
+
     // @interface OSNotification : NSObject
     [BaseType(typeof(NSObject))]
     interface OSNotification

--- a/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
+++ b/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
@@ -8,6 +8,7 @@ using WebKit;
 
 namespace Com.OneSignal.iOS
 {
+    [Internal]
     [BaseType(typeof(NSObject))]
     interface OneSignalCoreHelper
     {
@@ -18,6 +19,7 @@ namespace Com.OneSignal.iOS
 
     [Protocol]
     [Model]
+    [Internal]
     [BaseType(typeof(NSObject))]
     interface OneSignalNotificationCenterDelegateProxy
     {

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
+    <InternalsVisibleTo Include="OneSignalSDK.DotNet.iOS" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />

--- a/OneSignalSDK.DotNet.iOS/iOSNotificationCenterDelegateProxy.cs
+++ b/OneSignalSDK.DotNet.iOS/iOSNotificationCenterDelegateProxy.cs
@@ -57,6 +57,8 @@ internal sealed class iOSNotificationCenterDelegateProxy
     {
         if (OneSignalCoreHelper.IsOneSignalPayload(notification.Request.Content.UserInfo))
         {
+            // OneSignal's native IMP owns the real completion for its payloads.
+            // Let the inner delegate observe the notification without completing it twice.
             _innerDelegate.WillPresentNotification(center, notification, _ => { });
             return;
         }

--- a/OneSignalSDK.DotNet.iOS/iOSNotificationCenterDelegateProxy.cs
+++ b/OneSignalSDK.DotNet.iOS/iOSNotificationCenterDelegateProxy.cs
@@ -1,0 +1,124 @@
+using System.Runtime.InteropServices;
+using Com.OneSignal.iOS;
+using ObjCRuntime;
+using UserNotifications;
+
+namespace OneSignalSDK.DotNet.iOS;
+
+internal sealed class iOSNotificationCenterDelegateProxy
+    : OneSignalNotificationCenterDelegateProxy,
+        IUNUserNotificationCenterDelegate
+{
+    private const string WillPresentSelector =
+        "userNotificationCenter:willPresentNotification:withCompletionHandler:";
+    private const string OneSignalWillPresentSelector =
+        "onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:";
+    private const string DidReceiveResponseSelector =
+        "userNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:";
+    private const string OneSignalDidReceiveResponseSelector =
+        "onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:";
+
+    private readonly IUNUserNotificationCenterDelegate _innerDelegate;
+
+    public iOSNotificationCenterDelegateProxy(IUNUserNotificationCenterDelegate innerDelegate)
+    {
+        _innerDelegate = innerDelegate;
+    }
+
+    public override void WillPresentNotification(
+        UNUserNotificationCenter center,
+        UNNotification notification,
+        Action<UNNotificationPresentationOptions> completionHandler
+    ) => ForwardWillPresentNotification(center, notification, completionHandler);
+
+    public override void DidReceiveNotificationResponse(
+        UNUserNotificationCenter center,
+        UNNotificationResponse response,
+        Action completionHandler
+    ) => _innerDelegate.DidReceiveNotificationResponse(center, response, completionHandler);
+
+    public override void OneSignalWillPresentNotification(
+        UNUserNotificationCenter center,
+        UNNotification notification,
+        Action<UNNotificationPresentationOptions> completionHandler
+    ) => ForwardWillPresentNotification(center, notification, completionHandler);
+
+    public override void OneSignalDidReceiveNotificationResponse(
+        UNUserNotificationCenter center,
+        UNNotificationResponse response,
+        Action completionHandler
+    ) => _innerDelegate.DidReceiveNotificationResponse(center, response, completionHandler);
+
+    private void ForwardWillPresentNotification(
+        UNUserNotificationCenter center,
+        UNNotification notification,
+        Action<UNNotificationPresentationOptions> completionHandler
+    )
+    {
+        if (OneSignalCoreHelper.IsOneSignalPayload(notification.Request.Content.UserInfo))
+        {
+            _innerDelegate.WillPresentNotification(center, notification, _ => { });
+            return;
+        }
+
+        _innerDelegate.WillPresentNotification(center, notification, completionHandler);
+    }
+
+    public static bool RepairOneSignalDispatch()
+    {
+        // The exported aliases make native injection exchange two managed IMPs.
+        // Restore OneSignal's implementation on the Apple selectors afterward.
+        var proxyClass = Class.GetHandle(typeof(iOSNotificationCenterDelegateProxy));
+        var oneSignalClass = Class.GetHandle("OneSignalNotificationsUNUserNotificationCenter");
+        if (proxyClass == IntPtr.Zero || oneSignalClass == IntPtr.Zero)
+            return false;
+
+        return InstallOneSignalImplementation(
+                proxyClass,
+                oneSignalClass,
+                WillPresentSelector,
+                OneSignalWillPresentSelector
+            )
+            && InstallOneSignalImplementation(
+                proxyClass,
+                oneSignalClass,
+                DidReceiveResponseSelector,
+                OneSignalDidReceiveResponseSelector
+            );
+    }
+
+    private static bool InstallOneSignalImplementation(
+        IntPtr proxyClass,
+        IntPtr oneSignalClass,
+        string targetSelectorName,
+        string oneSignalSelectorName
+    )
+    {
+        var targetMethod = class_getInstanceMethod(
+            proxyClass,
+            Selector.GetHandle(targetSelectorName)
+        );
+        var oneSignalMethod = class_getInstanceMethod(
+            oneSignalClass,
+            Selector.GetHandle(oneSignalSelectorName)
+        );
+        if (targetMethod == IntPtr.Zero || oneSignalMethod == IntPtr.Zero)
+            return false;
+
+        var oneSignalImplementation = method_getImplementation(oneSignalMethod);
+        if (oneSignalImplementation == IntPtr.Zero)
+            return false;
+
+        method_setImplementation(targetMethod, oneSignalImplementation);
+        return true;
+    }
+
+    [DllImport(Constants.ObjectiveCLibrary)]
+    private static extern IntPtr class_getInstanceMethod(IntPtr cls, IntPtr selector);
+
+    [DllImport(Constants.ObjectiveCLibrary)]
+    private static extern IntPtr method_getImplementation(IntPtr method);
+
+    [DllImport(Constants.ObjectiveCLibrary)]
+    private static extern IntPtr method_setImplementation(IntPtr method, IntPtr implementation);
+}

--- a/OneSignalSDK.DotNet.iOS/iOSOneSignal.cs
+++ b/OneSignalSDK.DotNet.iOS/iOSOneSignal.cs
@@ -9,12 +9,17 @@ using OneSignalSDK.DotNet.Core.Notifications;
 using OneSignalSDK.DotNet.Core.Session;
 using OneSignalSDK.DotNet.Core.User;
 using OneSignalSDK.DotNet.iOS.Utilities;
+using UIKit;
+using UserNotifications;
 using OneSignalNative = Com.OneSignal.iOS.OneSignal;
 
 namespace OneSignalSDK.DotNet.iOS;
 
 public class iOSOneSignal : IOneSignal
 {
+    private iOSNotificationCenterDelegateProxy? _notificationCenterDelegateProxy;
+    private NSObject? _notificationDelegateObserver;
+
     public IUserManager User { get; } = new iOSUserManager();
 
     public ISessionManager Session { get; } = new iOSSessionManager();
@@ -49,11 +54,56 @@ public class iOSOneSignal : IOneSignal
             Com.OneSignal.iOS.OneSignalWrapper.SdkVersion = version;
         }
 
+        var notificationCenter = UNUserNotificationCenter.Current;
+        var existingDelegate = notificationCenter.Delegate;
+        if (existingDelegate != null && existingDelegate is not iOSNotificationCenterDelegateProxy)
+        {
+            _notificationCenterDelegateProxy = new iOSNotificationCenterDelegateProxy(
+                existingDelegate
+            );
+            notificationCenter.Delegate = _notificationCenterDelegateProxy;
+        }
+
         OneSignalNative.Initialize(appId, new NSDictionary());
+
+        if (
+            _notificationCenterDelegateProxy != null
+            && !iOSNotificationCenterDelegateProxy.RepairOneSignalDispatch()
+        )
+        {
+            throw new InvalidOperationException(
+                "OneSignal could not install its iOS notification delegate compatibility proxy."
+            );
+        }
+
+        if (_notificationCenterDelegateProxy != null)
+        {
+            _notificationDelegateObserver ??= NSNotificationCenter.DefaultCenter.AddObserver(
+                UIApplication.DidBecomeActiveNotification,
+                _ => VerifyNotificationDelegate()
+            );
+        }
 
         ((iOSUserManager)User).Initialize();
         ((iOSNotificationsManager)Notifications).Initialize();
         ((iOSInAppMessagesManager)InAppMessages).Initialize();
+    }
+
+    private void VerifyNotificationDelegate()
+    {
+        if (
+            _notificationCenterDelegateProxy != null
+            && !ReferenceEquals(
+                UNUserNotificationCenter.Current.Delegate,
+                _notificationCenterDelegateProxy
+            )
+        )
+        {
+            System.Diagnostics.Debug.WriteLine(
+                "OneSignal iOS notification delegate proxy was replaced after initialization; "
+                    + "compatibility forwarding is no longer active."
+            );
+        }
     }
 
     public void Login(string externalId, string? jwtBearerToken = null)

--- a/examples/plugin-local-notif/MauiProgram.cs
+++ b/examples/plugin-local-notif/MauiProgram.cs
@@ -1,6 +1,9 @@
 using OneSignalSDK.DotNet;
 using Plugin.LocalNotification;
 using OsLogLevel = OneSignalSDK.DotNet.Core.Debug.LogLevel;
+#if IOS
+using Microsoft.Maui.LifecycleEvents;
+#endif
 
 namespace PluginLocalNotifDemo;
 
@@ -11,27 +14,51 @@ public static class MauiProgram
     public static MauiApp CreateMauiApp()
     {
         var builder = MauiApp.CreateBuilder();
+        var appId = DefaultAppId;
 
         builder.UseMauiApp<App>().UseLocalNotification();
+
+#if IOS
+        builder.ConfigureLifecycleEvents(events =>
+        {
+            events.AddiOS(ios =>
+            {
+                ios.FinishedLaunching(
+                    (_, _) =>
+                    {
+                        InitializeOneSignal(appId);
+                        return true;
+                    }
+                );
+            });
+        });
+#endif
 
         var app = builder.Build();
 
         DotEnv.Load();
 
         var envAppId = DotEnv.Get("ONESIGNAL_APP_ID");
-        var appId =
+        appId =
             string.IsNullOrWhiteSpace(envAppId) || envAppId == "your-onesignal-app-id"
                 ? DefaultAppId
                 : envAppId.Trim();
 
         OneSignal.Debug.LogLevel = OsLogLevel.VERBOSE;
-        OneSignal.Initialize(appId);
-
         OneSignal.Notifications.WillDisplay += (s, e) =>
             System.Diagnostics.Debug.WriteLine("OneSignal notification will display");
         OneSignal.Notifications.Clicked += (s, e) =>
             System.Diagnostics.Debug.WriteLine("OneSignal notification clicked");
 
+#if !IOS
+        InitializeOneSignal(appId);
+#endif
+
         return app;
+    }
+
+    private static void InitializeOneSignal(string appId)
+    {
+        OneSignal.Initialize(appId);
     }
 }

--- a/examples/plugin-local-notif/MauiProgram.cs
+++ b/examples/plugin-local-notif/MauiProgram.cs
@@ -13,8 +13,15 @@ public static class MauiProgram
 
     public static MauiApp CreateMauiApp()
     {
+        DotEnv.Load();
+
+        var envAppId = DotEnv.Get("ONESIGNAL_APP_ID");
+        var appId =
+            string.IsNullOrWhiteSpace(envAppId) || envAppId == "your-onesignal-app-id"
+                ? DefaultAppId
+                : envAppId.Trim();
+
         var builder = MauiApp.CreateBuilder();
-        var appId = DefaultAppId;
 
         builder.UseMauiApp<App>().UseLocalNotification();
 
@@ -36,14 +43,6 @@ public static class MauiProgram
 
         var app = builder.Build();
 
-        DotEnv.Load();
-
-        var envAppId = DotEnv.Get("ONESIGNAL_APP_ID");
-        appId =
-            string.IsNullOrWhiteSpace(envAppId) || envAppId == "your-onesignal-app-id"
-                ? DefaultAppId
-                : envAppId.Trim();
-
         OneSignal.Debug.LogLevel = OsLogLevel.VERBOSE;
         OneSignal.Notifications.WillDisplay += (s, e) =>
             System.Diagnostics.Debug.WriteLine("OneSignal notification will display");
@@ -51,6 +50,7 @@ public static class MauiProgram
             System.Diagnostics.Debug.WriteLine("OneSignal notification clicked");
 
 #if !IOS
+        // iOS initializes in FinishedLaunching after the plugin installs its delegate.
         InitializeOneSignal(appId);
 #endif
 

--- a/examples/plugin-local-notif/README.md
+++ b/examples/plugin-local-notif/README.md
@@ -76,8 +76,14 @@ a later `FinishedLaunching` handler. Android still initializes immediately.
 This is an experimental compatibility path, not a general delegate coordinator:
 
 - Replacing `UNUserNotificationCenter.Current.Delegate` after
-  `OneSignal.Initialize` is not protected.
+  `OneSignal.Initialize` is not protected. The prototype only reports this
+  through `Debug.WriteLine`, so Release/AOT apps receive no warning.
 - It relies on private native OneSignal class and selector names.
+- If post-initialization IMP repair fails, initialization throws after the
+  native SDK has already started; there is no safe rollback to the original
+  managed delegate.
+- The low-level binding helper and proxy model are internal implementation
+  details and are not supported consumer APIs.
 - Each bundled native iOS SDK version must be verified in both Debug and
   Release/AOT builds.
 

--- a/examples/plugin-local-notif/README.md
+++ b/examples/plugin-local-notif/README.md
@@ -23,7 +23,14 @@ onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:
 
 Both failures point at the same interaction: OneSignal's native iOS SDK swizzles
 `UNUserNotificationCenterDelegate` methods, while `Plugin.LocalNotification`
-installs its own delegate that only implements the normal Apple selectors.
+installs its own managed delegate that only implements the normal Apple
+selectors. The .NET runtime cannot marshal the OneSignal-prefixed selector back
+to that managed type.
+
+This branch prototypes an SDK-owned delegate proxy. The proxy is installed
+between OneSignal and the existing local-notification delegate, provides
+registrar metadata for both selector names, and restores OneSignal's native
+implementations after swizzling.
 
 ## Run
 
@@ -50,7 +57,10 @@ devices.
 3. Tap `Request LocalNotification Permission`.
 4. Tap `Show Local Notification` while the app is foregrounded.
 5. If the notification is delivered, tap it from Notification Center.
-6. Watch device logs for the `onesignalUserNotificationCenter:*` selector crash.
+6. Send a OneSignal push while the app is foregrounded, then tap a push from
+   Notification Center.
+7. Confirm local callbacks and OneSignal `WillDisplay`/`Clicked` callbacks run
+   without an `ObjCRuntime.RuntimeException`.
 
 The bundled app ID matches the main demo app's default ID when
 `ONESIGNAL_APP_ID` is missing or still set to the placeholder. To test against a
@@ -58,8 +68,20 @@ different OneSignal app, set `ONESIGNAL_APP_ID` in `.env`.
 
 ## Notes
 
-The native OneSignal iOS SDK now documents disabling swizzling via
+The proxy must capture the third-party delegate before OneSignal starts native
+initialization. `UseLocalNotification` installs its delegate during
+`FinishedLaunching`, so this sample registers OneSignal's iOS initialization in
+a later `FinishedLaunching` handler. Android still initializes immediately.
+
+This is an experimental compatibility path, not a general delegate coordinator:
+
+- Replacing `UNUserNotificationCenter.Current.Delegate` after
+  `OneSignal.Initialize` is not protected.
+- It relies on private native OneSignal class and selector names.
+- Each bundled native iOS SDK version must be verified in both Debug and
+  Release/AOT builds.
+
+The supported fallback remains disabling swizzling with
 `OneSignal_disable_swizzling` and manually forwarding notification delegate
-methods. This .NET binding currently does not expose the newer manual forwarding
-APIs, so this sample keeps swizzling enabled and demonstrates the reported
-interaction directly.
+methods. Those native manual-integration APIs are not currently exposed by this
+.NET binding.


### PR DESCRIPTION
# Description
## One Line Summary
Prototypes an iOS managed delegate proxy that preserves OneSignal swizzling while forwarding third-party notification delegates safely.

## Details
### Motivation
OneSignal's prefixed swizzled selectors can crash the .NET registrar when `Plugin.LocalNotification` installs a managed `UNUserNotificationCenterDelegate`. The proxy supplies generated block-conversion metadata for both selector forms and prevents that registrar failure.

### Scope
- Wraps an existing iOS notification delegate before native OneSignal initialization.
- Restores OneSignal's native IMPs after selector injection.
- Keeps OneSignal foreground lifecycle/display handling while forwarding local notifications to the captured delegate.
- Detects and logs delegates replaced after initialization.
- Updates the demo's iOS `FinishedLaunching` ordering so the plugin delegate exists before OneSignal initializes.

This is an experimental compatibility path. It relies on private native OneSignal class/selector names and does not protect delegates assigned after `OneSignal.Initialize`. The generated binding helper/model types support the internal implementation and are not intended as consumer APIs.

Stacked on #188.

# Testing
## Manual testing
- iOS Debug simulator: verified Plugin.LocalNotification foreground display (`response 27`).
- iOS Debug simulator: verified OneSignal foreground lifecycle and banner display (`response 7`).
- iOS Release/AOT simulator: repeated local and OneSignal foreground paths without `ObjCRuntime.RuntimeException`.
- Confirmed removing the `FinishedLaunching` ordering reproduces the native crash; restoring it resolves the crash.
- Android Debug build passed.
- `csharpier check .` passed.

Notification-open behavior was manually smoke-tested, but `Clicked` callback logging should receive additional Release/AOT validation before treating this prototype as production-ready.

# Affected code checklist
- [x] Notifications
  - [x] Display
  - [x] Open
  - [x] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [x] Public API changes

# Checklist
## Overview
- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
- [x] I have included test coverage for these changes, or explained why they are not needed
- [x] All automated tests pass, or I explained why that is not possible
- [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
- [x] Code is as readable as possible
- [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)