### PR TITLE
feat: [SDK-4788] add iOS manual notification forwarding

### DIFF
--- a/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
+++ b/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
@@ -8,6 +8,15 @@ using WebKit;
 
 namespace Com.OneSignal.iOS
 {
+    [Internal]
+    [BaseType(typeof(NSObject))]
+    interface OneSignalCoreHelper
+    {
+        [Static]
+        [Export("isOneSignalPayload:")]
+        bool IsOneSignalPayload(NSDictionary payload);
+    }
+
     // @interface OSNotification : NSObject
     [BaseType(typeof(NSObject))]
     interface OSNotification
@@ -344,6 +353,30 @@ namespace Com.OneSignal.iOS
         //[Static, Abstract]
         [Export("clearAll")]
         void ClearAll();
+
+        [Export("didRegisterForRemoteNotificationsWithDeviceToken:")]
+        void DidRegisterForRemoteNotifications(NSData deviceToken);
+
+        [Export("didFailToRegisterForRemoteNotificationsWithError:")]
+        void DidFailToRegisterForRemoteNotifications(NSError error);
+
+        [Export("didReceiveRemoteNotification:completionHandler:")]
+        void DidReceiveRemoteNotification(
+            NSDictionary userInfo,
+            Action<UIBackgroundFetchResult> completionHandler
+        );
+
+        [Export("willPresentNotificationWithPayload:completion:")]
+        void WillPresentNotification(
+            NSDictionary payload,
+            OSNotificationDisplayResponse completion
+        );
+
+        [Export("didReceiveNotificationResponse:")]
+        void DidReceiveNotificationResponse(UNNotificationResponse response);
+
+        [Export("setBadgeCount:")]
+        void SetBadgeCount(nint badgeCount);
     }
 
     // @interface OSPushSubscriptionChangedState : NSObject

--- a/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
+++ b/OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
+    <InternalsVisibleTo Include="OneSignalSDK.DotNet.iOS" />
   </ItemGroup>
   <ItemGroup>
     <ObjcBindingCoreSource Include="StructsAndEnums.cs" />

--- a/OneSignalSDK.DotNet.iOS/NotificationsManualIntegration.cs
+++ b/OneSignalSDK.DotNet.iOS/NotificationsManualIntegration.cs
@@ -1,0 +1,141 @@
+using Foundation;
+using UIKit;
+using UserNotifications;
+using OneSignalNative = Com.OneSignal.iOS.OneSignal;
+
+namespace OneSignalSDK.DotNet.iOS;
+
+/// <summary>
+/// Supported iOS notification callbacks for apps that disable OneSignal method swizzling.
+/// </summary>
+public static class NotificationsManualIntegration
+{
+    private const string DisableSwizzlingKey = "OneSignal_disable_swizzling";
+
+    /// <summary>
+    /// Returns whether manual notification forwarding is enabled in the app's Info.plist.
+    /// </summary>
+    public static bool IsEnabled =>
+        (NSBundle.MainBundle.ObjectForInfoDictionary(DisableSwizzlingKey) as NSNumber)?.BoolValue
+        ?? false;
+
+    /// <summary>
+    /// Returns whether a notification payload belongs to OneSignal.
+    /// </summary>
+    public static bool IsOneSignalNotification(NSDictionary payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        return Com.OneSignal.iOS.OneSignalCoreHelper.IsOneSignalPayload(payload);
+    }
+
+    /// <summary>
+    /// Forwards successful APNs registration to OneSignal.
+    /// </summary>
+    public static void DidRegisterForRemoteNotifications(NSData deviceToken)
+    {
+        EnsureEnabled();
+        ArgumentNullException.ThrowIfNull(deviceToken);
+        OneSignalNative.Notifications.DidRegisterForRemoteNotifications(deviceToken);
+    }
+
+    /// <summary>
+    /// Forwards failed APNs registration to OneSignal.
+    /// </summary>
+    public static void DidFailToRegisterForRemoteNotifications(NSError error)
+    {
+        EnsureEnabled();
+        ArgumentNullException.ThrowIfNull(error);
+        OneSignalNative.Notifications.DidFailToRegisterForRemoteNotifications(error);
+    }
+
+    /// <summary>
+    /// Forwards a background remote notification to OneSignal. OneSignal owns the completion handler.
+    /// </summary>
+    public static void DidReceiveRemoteNotification(
+        NSDictionary userInfo,
+        Action<UIBackgroundFetchResult> completionHandler
+    )
+    {
+        EnsureEnabled();
+        ArgumentNullException.ThrowIfNull(userInfo);
+        ArgumentNullException.ThrowIfNull(completionHandler);
+        OneSignalNative.Notifications.DidReceiveRemoteNotification(userInfo, completionHandler);
+    }
+
+    /// <summary>
+    /// Handles a OneSignal foreground notification and completes Apple's callback exactly once.
+    /// </summary>
+    /// <returns><see langword="true"/> when the notification belonged to OneSignal.</returns>
+    public static bool TryHandleWillPresentNotification(
+        UNNotification notification,
+        UNNotificationPresentationOptions presentationOptions,
+        Action<UNNotificationPresentationOptions> completionHandler
+    )
+    {
+        EnsureEnabled();
+        ArgumentNullException.ThrowIfNull(notification);
+        ArgumentNullException.ThrowIfNull(completionHandler);
+
+        var payload = notification.Request.Content.UserInfo;
+        if (!IsOneSignalNotification(payload))
+            return false;
+
+        OneSignalNative.Notifications.WillPresentNotification(
+            payload,
+            displayableNotification =>
+                completionHandler(
+                    displayableNotification == null
+                        ? (UNNotificationPresentationOptions)0
+                        : presentationOptions
+                )
+        );
+        return true;
+    }
+
+    /// <summary>
+    /// Handles a OneSignal notification response and completes Apple's callback exactly once.
+    /// </summary>
+    /// <returns><see langword="true"/> when the notification belonged to OneSignal.</returns>
+    public static bool TryHandleNotificationResponse(
+        UNNotificationResponse response,
+        Action completionHandler
+    )
+    {
+        EnsureEnabled();
+        ArgumentNullException.ThrowIfNull(response);
+        ArgumentNullException.ThrowIfNull(completionHandler);
+
+        if (!IsOneSignalNotification(response.Notification.Request.Content.UserInfo))
+            return false;
+
+        try
+        {
+            OneSignalNative.Notifications.DidReceiveNotificationResponse(response);
+        }
+        finally
+        {
+            completionHandler();
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Sets the app icon badge count through OneSignal.
+    /// </summary>
+    public static void SetBadgeCount(nint badgeCount)
+    {
+        EnsureEnabled();
+        OneSignalNative.Notifications.SetBadgeCount(badgeCount);
+    }
+
+    private static void EnsureEnabled()
+    {
+        if (!IsEnabled)
+        {
+            throw new InvalidOperationException(
+                $"Set {DisableSwizzlingKey} to true in Info.plist before using manual integration."
+            );
+        }
+    }
+}

--- a/examples/plugin-local-notif/.env.example
+++ b/examples/plugin-local-notif/.env.example
@@ -1,2 +1,1 @@
-# Default App ID (used when ONESIGNAL_APP_ID is empty or missing): 77e32082-ea27-42e3-a898-c72e141824ef
 ONESIGNAL_APP_ID=your-onesignal-app-id

--- a/examples/plugin-local-notif/DotEnv.cs
+++ b/examples/plugin-local-notif/DotEnv.cs
@@ -2,8 +2,13 @@ namespace PluginLocalNotifDemo;
 
 public static class DotEnv
 {
+    private const string OneSignalAppIdPlaceholder = "your-onesignal-app-id";
     private static readonly Dictionary<string, string> Values = new();
     private static bool _loaded;
+
+    public static string OneSignalAppId => Get("ONESIGNAL_APP_ID").Trim();
+    public static bool HasOneSignalAppId =>
+        !string.IsNullOrWhiteSpace(OneSignalAppId) && OneSignalAppId != OneSignalAppIdPlaceholder;
 
     public static void Load()
     {

--- a/examples/plugin-local-notif/MainPage.cs
+++ b/examples/plugin-local-notif/MainPage.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json;
 using OneSignalSDK.DotNet;
 using OneSignalSDK.DotNet.Core.Notifications;
 using OneSignalSDK.DotNet.Core.User;
@@ -88,6 +90,24 @@ public class MainPage : ContentPage
             );
         };
 
+        var showOneSignalNotificationButton = new Button
+        {
+            Text = "Show OneSignal Notification",
+            AutomationId = "show_onesignal_notification_button",
+        };
+        showOneSignalNotificationButton.Clicked += async (s, e) =>
+        {
+            showOneSignalNotificationButton.IsEnabled = false;
+            try
+            {
+                await SendSimpleOneSignalNotificationAsync();
+            }
+            finally
+            {
+                showOneSignalNotificationButton.IsEnabled = true;
+            }
+        };
+
         var clearButton = new Button
         {
             Text = "Clear Delivered Notifications",
@@ -133,6 +153,7 @@ public class MainPage : ContentPage
                     requestOneSignalPermissionButton,
                     requestLocalPermissionButton,
                     showLocalNotificationButton,
+                    showOneSignalNotificationButton,
                     clearButton,
                     refreshPushInfoButton,
                     _statusLabel,
@@ -160,10 +181,9 @@ public class MainPage : ContentPage
     {
         var pushSubscription = OneSignal.User.PushSubscription;
         _pushInfoLabel.Text =
-            $"OneSignal ID: {FormatValue(OneSignal.User.OneSignalId)}\n"
-            + $"Push subscription ID: {FormatValue(pushSubscription.Id)}\n"
-            + $"Push opted in: {pushSubscription.OptedIn}\n"
-            + $"Push token: {FormatValue(pushSubscription.Token)}";
+            $"OneSignal ID:\n{FormatValue(OneSignal.User.OneSignalId)}\n"
+            + $"Push subscription ID:\n{FormatValue(pushSubscription.Id)}\n"
+            + $"Push opted in: {pushSubscription.OptedIn}";
     }
 
     private void OnPermissionChanged(object? sender, NotificationPermissionChangedEventArgs args)
@@ -183,6 +203,51 @@ public class MainPage : ContentPage
     private void OnUserChanged(object? sender, UserStateChangedEventArgs args)
     {
         MainThread.BeginInvokeOnMainThread(RefreshPushInfoLabel);
+    }
+
+    private async Task SendSimpleOneSignalNotificationAsync()
+    {
+        if (!DotEnv.HasOneSignalAppId)
+        {
+            SetStatus("Set ONESIGNAL_APP_ID in .env before sending a OneSignal notification.");
+            return;
+        }
+
+        var pushSubscriptionId = OneSignal.User.PushSubscription.Id;
+        if (string.IsNullOrWhiteSpace(pushSubscriptionId))
+        {
+            SetStatus(
+                "No OneSignal push subscription ID yet. Refresh after permission is granted."
+            );
+            return;
+        }
+
+        using var client = new HttpClient();
+        client.DefaultRequestHeaders.Add("Accept", "application/vnd.onesignal.v1+json");
+
+        var payload = new Dictionary<string, object>
+        {
+            ["app_id"] = DotEnv.OneSignalAppId,
+            ["headings"] = new Dictionary<string, string> { ["en"] = "Simple Notification" },
+            ["contents"] = new Dictionary<string, string>
+            {
+                ["en"] = "This is a simple push notification",
+            },
+            ["include_subscription_ids"] = new[] { pushSubscriptionId },
+        };
+
+        var json = JsonSerializer.Serialize(payload);
+        var response = await client.PostAsync(
+            "https://onesignal.com/api/v1/notifications",
+            new StringContent(json, Encoding.UTF8, "application/json")
+        );
+        var responseJson = await response.Content.ReadAsStringAsync();
+
+        SetStatus(
+            response.IsSuccessStatusCode
+                ? $"OneSignal notification requested: {responseJson}"
+                : $"OneSignal notification failed: {responseJson}"
+        );
     }
 
     private void SetStatus(string message)

--- a/examples/plugin-local-notif/MauiProgram.cs
+++ b/examples/plugin-local-notif/MauiProgram.cs
@@ -37,9 +37,9 @@ public static class MauiProgram
 
         OneSignal.Debug.LogLevel = OsLogLevel.VERBOSE;
         OneSignal.Notifications.WillDisplay += (s, e) =>
-            System.Diagnostics.Debug.WriteLine("OneSignal notification will display");
+            Console.WriteLine("OneSignal notification will display");
         OneSignal.Notifications.Clicked += (s, e) =>
-            System.Diagnostics.Debug.WriteLine("OneSignal notification clicked");
+            Console.WriteLine("OneSignal notification clicked");
 
 #if !IOS
         InitializeOneSignal();

--- a/examples/plugin-local-notif/MauiProgram.cs
+++ b/examples/plugin-local-notif/MauiProgram.cs
@@ -1,6 +1,9 @@
 using OneSignalSDK.DotNet;
 using Plugin.LocalNotification;
 using OsLogLevel = OneSignalSDK.DotNet.Core.Debug.LogLevel;
+#if IOS
+using Microsoft.Maui.LifecycleEvents;
+#endif
 
 namespace PluginLocalNotifDemo;
 
@@ -10,12 +13,6 @@ public static class MauiProgram
 
     public static MauiApp CreateMauiApp()
     {
-        var builder = MauiApp.CreateBuilder();
-
-        builder.UseMauiApp<App>().UseLocalNotification();
-
-        var app = builder.Build();
-
         DotEnv.Load();
 
         var envAppId = DotEnv.Get("ONESIGNAL_APP_ID");
@@ -24,14 +21,44 @@ public static class MauiProgram
                 ? DefaultAppId
                 : envAppId.Trim();
 
-        OneSignal.Debug.LogLevel = OsLogLevel.VERBOSE;
-        OneSignal.Initialize(appId);
+        var builder = MauiApp.CreateBuilder();
 
+        builder.UseMauiApp<App>().UseLocalNotification();
+
+#if IOS
+        builder.ConfigureLifecycleEvents(events =>
+        {
+            events.AddiOS(ios =>
+            {
+                ios.FinishedLaunching(
+                    (_, _) =>
+                    {
+                        OneSignalNotificationDelegate.Install();
+                        InitializeOneSignal(appId);
+                        return true;
+                    }
+                );
+            });
+        });
+#endif
+
+        var app = builder.Build();
+
+        OneSignal.Debug.LogLevel = OsLogLevel.VERBOSE;
         OneSignal.Notifications.WillDisplay += (s, e) =>
             System.Diagnostics.Debug.WriteLine("OneSignal notification will display");
         OneSignal.Notifications.Clicked += (s, e) =>
             System.Diagnostics.Debug.WriteLine("OneSignal notification clicked");
 
+#if !IOS
+        InitializeOneSignal(appId);
+#endif
+
         return app;
+    }
+
+    private static void InitializeOneSignal(string appId)
+    {
+        OneSignal.Initialize(appId);
     }
 }

--- a/examples/plugin-local-notif/MauiProgram.cs
+++ b/examples/plugin-local-notif/MauiProgram.cs
@@ -9,17 +9,9 @@ namespace PluginLocalNotifDemo;
 
 public static class MauiProgram
 {
-    private const string DefaultAppId = "77e32082-ea27-42e3-a898-c72e141824ef";
-
     public static MauiApp CreateMauiApp()
     {
         DotEnv.Load();
-
-        var envAppId = DotEnv.Get("ONESIGNAL_APP_ID");
-        var appId =
-            string.IsNullOrWhiteSpace(envAppId) || envAppId == "your-onesignal-app-id"
-                ? DefaultAppId
-                : envAppId.Trim();
 
         var builder = MauiApp.CreateBuilder();
 
@@ -33,8 +25,7 @@ public static class MauiProgram
                 ios.FinishedLaunching(
                     (_, _) =>
                     {
-                        OneSignalNotificationDelegate.Install();
-                        InitializeOneSignal(appId);
+                        InitializeOneSignal(installNotificationDelegate: true);
                         return true;
                     }
                 );
@@ -51,14 +42,29 @@ public static class MauiProgram
             System.Diagnostics.Debug.WriteLine("OneSignal notification clicked");
 
 #if !IOS
-        InitializeOneSignal(appId);
+        InitializeOneSignal();
 #endif
 
         return app;
     }
 
-    private static void InitializeOneSignal(string appId)
+    private static void InitializeOneSignal(bool installNotificationDelegate = false)
     {
-        OneSignal.Initialize(appId);
+        if (!DotEnv.HasOneSignalAppId)
+        {
+            System.Diagnostics.Debug.WriteLine(
+                "Set ONESIGNAL_APP_ID in .env to initialize OneSignal."
+            );
+            return;
+        }
+
+#if IOS
+        if (installNotificationDelegate)
+        {
+            OneSignalNotificationDelegate.Install();
+        }
+#endif
+
+        OneSignal.Initialize(DotEnv.OneSignalAppId);
     }
 }

--- a/examples/plugin-local-notif/Platforms/iOS/AppDelegate.cs
+++ b/examples/plugin-local-notif/Platforms/iOS/AppDelegate.cs
@@ -1,6 +1,8 @@
 using Foundation;
 using Microsoft.Maui;
 using Microsoft.Maui.Hosting;
+using OneSignalSDK.DotNet.iOS;
+using UIKit;
 
 namespace PluginLocalNotifDemo;
 
@@ -8,4 +10,26 @@ namespace PluginLocalNotifDemo;
 public class AppDelegate : MauiUIApplicationDelegate
 {
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+
+    [Export("application:didRegisterForRemoteNotificationsWithDeviceToken:")]
+    public void DidRegisterForRemoteNotifications(UIApplication application, NSData deviceToken)
+    {
+        NotificationsManualIntegration.DidRegisterForRemoteNotifications(deviceToken);
+    }
+
+    [Export("application:didFailToRegisterForRemoteNotificationsWithError:")]
+    public void DidFailToRegisterForRemoteNotifications(UIApplication application, NSError error)
+    {
+        NotificationsManualIntegration.DidFailToRegisterForRemoteNotifications(error);
+    }
+
+    [Export("application:didReceiveRemoteNotification:fetchCompletionHandler:")]
+    public void DidReceiveRemoteNotification(
+        UIApplication application,
+        NSDictionary userInfo,
+        Action<UIBackgroundFetchResult> completionHandler
+    )
+    {
+        NotificationsManualIntegration.DidReceiveRemoteNotification(userInfo, completionHandler);
+    }
 }

--- a/examples/plugin-local-notif/Platforms/iOS/Info.plist
+++ b/examples/plugin-local-notif/Platforms/iOS/Info.plist
@@ -36,6 +36,8 @@
     <array>
         <string>remote-notification</string>
     </array>
+    <key>OneSignal_disable_swizzling</key>
+    <true/>
     <key>aps-environment</key>
     <string>development</string>
 </dict>

--- a/examples/plugin-local-notif/Platforms/iOS/OneSignalNotificationDelegate.cs
+++ b/examples/plugin-local-notif/Platforms/iOS/OneSignalNotificationDelegate.cs
@@ -1,0 +1,79 @@
+using OneSignalSDK.DotNet.iOS;
+using UserNotifications;
+
+namespace PluginLocalNotifDemo;
+
+internal sealed class OneSignalNotificationDelegate : UNUserNotificationCenterDelegate
+{
+    private static OneSignalNotificationDelegate? _instance;
+    private readonly IUNUserNotificationCenterDelegate _localNotificationDelegate;
+
+    private OneSignalNotificationDelegate(
+        IUNUserNotificationCenterDelegate localNotificationDelegate
+    )
+    {
+        _localNotificationDelegate = localNotificationDelegate;
+    }
+
+    public static void Install()
+    {
+        var notificationCenter = UNUserNotificationCenter.Current;
+        var localNotificationDelegate =
+            notificationCenter.Delegate
+            ?? throw new InvalidOperationException(
+                "Plugin.LocalNotification must install its iOS delegate before OneSignal."
+            );
+
+        _instance = new OneSignalNotificationDelegate(localNotificationDelegate);
+        notificationCenter.Delegate = _instance;
+    }
+
+    public override void WillPresentNotification(
+        UNUserNotificationCenter center,
+        UNNotification notification,
+        Action<UNNotificationPresentationOptions> completionHandler
+    )
+    {
+        var presentationOptions =
+            UNNotificationPresentationOptions.Banner
+            | UNNotificationPresentationOptions.List
+            | UNNotificationPresentationOptions.Sound
+            | UNNotificationPresentationOptions.Badge;
+
+        if (
+            NotificationsManualIntegration.TryHandleWillPresentNotification(
+                notification,
+                presentationOptions,
+                completionHandler
+            )
+        )
+        {
+            return;
+        }
+
+        _localNotificationDelegate.WillPresentNotification(center, notification, completionHandler);
+    }
+
+    public override void DidReceiveNotificationResponse(
+        UNUserNotificationCenter center,
+        UNNotificationResponse response,
+        Action completionHandler
+    )
+    {
+        if (
+            NotificationsManualIntegration.TryHandleNotificationResponse(
+                response,
+                completionHandler
+            )
+        )
+        {
+            return;
+        }
+
+        _localNotificationDelegate.DidReceiveNotificationResponse(
+            center,
+            response,
+            completionHandler
+        );
+    }
+}

--- a/examples/plugin-local-notif/README.md
+++ b/examples/plugin-local-notif/README.md
@@ -12,6 +12,7 @@ From this directory, run iOS:
 
 ```sh
 cp .env.example .env
+# Set ONESIGNAL_APP_ID in .env before launching.
 ./run-ios.sh
 ```
 
@@ -55,10 +56,11 @@ initialize OneSignal last.
 
 On iOS, verify local foreground display and tap, OneSignal foreground
 `WillDisplay` and banner presentation, background and silent delivery,
-OneSignal `Clicked`, and APNs token registration. No
+OneSignal `Clicked`, and APNs token registration. The
+`Show OneSignal Notification` button sends a push to the displayed subscription
+ID so these paths can be tested without opening the OneSignal dashboard. No
 `onesignalUserNotificationCenter:*` or
 `oneSignalDidRegisterForRemoteNotifications:*` registrar crash should occur.
 
-The bundled app ID matches the main demo app's default ID when
-`ONESIGNAL_APP_ID` is missing or still set to the placeholder. Set
-`ONESIGNAL_APP_ID` in `.env` to use a different OneSignal app.
+Set `ONESIGNAL_APP_ID` in `.env` before running the sample. The app does not
+fall back to a built-in OneSignal app ID.

--- a/examples/plugin-local-notif/README.md
+++ b/examples/plugin-local-notif/README.md
@@ -1,29 +1,10 @@
-# OneSignal + Plugin.LocalNotification Repro
+# OneSignal + Plugin.LocalNotification
 
-Minimal .NET MAUI app for investigating the iOS interaction reported in
-[GitHub issue #132](https://github.com/OneSignal/OneSignal-DotNet-SDK/issues/132).
-
-## What This Reproduces
-
-Issue #132 reports an iOS crash when `OneSignalSDK.DotNet` and
-`Plugin.LocalNotification` are both installed:
-
-```text
-Cannot get the method descriptor for the selector
-'onesignalUserNotificationCenter:didReceiveNotificationResponse:withCompletionHandler:'
-on the type 'Plugin.LocalNotification.Platforms.UserNotificationCenterDelegate'
-```
-
-Related issue #110 reported the same failure shape for the foreground delivery
-selector:
-
-```text
-onesignalUserNotificationCenter:willPresentNotification:withCompletionHandler:
-```
-
-Both failures point at the same interaction: OneSignal's native iOS SDK swizzles
-`UNUserNotificationCenterDelegate` methods, while `Plugin.LocalNotification`
-installs its own delegate that only implements the normal Apple selectors.
+This .NET MAUI app demonstrates the supported iOS manual-integration path for
+using OneSignal with `Plugin.LocalNotification`. It avoids the managed delegate
+selector crash reported in
+[GitHub issue #132](https://github.com/OneSignal/OneSignal-DotNet-SDK/issues/132)
+without relying on private selectors or Objective-C runtime patches.
 
 ## Run
 
@@ -43,23 +24,41 @@ Or run Android:
 The shared scripts select from currently booted simulators or connected Android
 devices.
 
-## Repro Steps
+## iOS Manual Integration
 
-1. Launch the app on iOS.
-2. Tap `Request OneSignal Permission`.
-3. Tap `Request LocalNotification Permission`.
-4. Tap `Show Local Notification` while the app is foregrounded.
-5. If the notification is delivered, tap it from Notification Center.
-6. Watch device logs for the `onesignalUserNotificationCenter:*` selector crash.
+The integration has four required parts:
+
+1. `Info.plist` sets `OneSignal_disable_swizzling` to `true`.
+2. `OneSignalNotificationDelegate` captures the delegate installed by
+   `Plugin.LocalNotification` and becomes the app's notification-center
+   delegate.
+3. `MauiProgram` installs that coordinator after the plugin's
+   `FinishedLaunching` callback, then initializes OneSignal.
+4. `AppDelegate` forwards APNs registration, registration failure, and
+   background remote-notification callbacks through
+   `NotificationsManualIntegration`.
+
+The coordinator routes OneSignal foreground and tap callbacks to
+`NotificationsManualIntegration`. Non-OneSignal notifications are forwarded to
+the plugin delegate. Each Apple completion handler has one owner:
+
+- OneSignal owns background remote-notification completion.
+- The manual integration completes OneSignal foreground and tap callbacks.
+- `Plugin.LocalNotification` completes callbacks for local notifications.
+
+The app must retain ownership of `UNUserNotificationCenter.Current.Delegate`.
+If another library replaces the coordinator after startup, forwarding stops.
+Install any library-owned delegate first, wrap it with the coordinator, and
+initialize OneSignal last.
+
+## Verify
+
+On iOS, verify local foreground display and tap, OneSignal foreground
+`WillDisplay` and banner presentation, background and silent delivery,
+OneSignal `Clicked`, and APNs token registration. No
+`onesignalUserNotificationCenter:*` or
+`oneSignalDidRegisterForRemoteNotifications:*` registrar crash should occur.
 
 The bundled app ID matches the main demo app's default ID when
-`ONESIGNAL_APP_ID` is missing or still set to the placeholder. To test against a
-different OneSignal app, set `ONESIGNAL_APP_ID` in `.env`.
-
-## Notes
-
-The native OneSignal iOS SDK now documents disabling swizzling via
-`OneSignal_disable_swizzling` and manually forwarding notification delegate
-methods. This .NET binding currently does not expose the newer manual forwarding
-APIs, so this sample keeps swizzling enabled and demonstrates the reported
-interaction directly.
+`ONESIGNAL_APP_ID` is missing or still set to the placeholder. Set
+`ONESIGNAL_APP_ID` in `.env` to use a different OneSignal app.

--- a/examples/plugin-local-notif/run-ios.sh
+++ b/examples/plugin-local-notif/run-ios.sh
@@ -2,4 +2,5 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+dotnet clean "$SCRIPT_DIR/plugin-local-notif.csproj" -f net10.0-ios
 "$SCRIPT_DIR/../run-ios.sh" "$SCRIPT_DIR/plugin-local-notif.csproj"


### PR DESCRIPTION
# Description
## One Line Summary
Adds a supported, opt-in iOS manual notification-forwarding API for apps that own `UNUserNotificationCenterDelegate`.

This is lower risk than the automatic proxy approach in #189 because it uses only the native SDK’s documented manual-forwarding APIs. It does not depend on private native class or selector names, patch Objective-C method implementations at runtime, or change behavior unless an app explicitly opts in.

## Details
### Motivation
Setting `OneSignal_disable_swizzling` currently disables OneSignal's automatic notification callback handling, but the .NET SDK does not expose the native manual-forwarding APIs. As a result, setting the flag alone leaves token registration, foreground display, clicks, and background notification processing without a supported forwarding path.

This PR makes disabling swizzling functional for .NET consumers. It exposes the native SDK's documented manual-forwarding path so apps can explicitly coordinate callbacks when another library, such as `Plugin.LocalNotification`, owns `UNUserNotificationCenterDelegate`. This also avoids the managed registrar crashes caused when native swizzling invokes dynamically injected selectors on managed delegates.

### Scope
- Binds the native APNs registration success/failure, background remote notification, foreground presentation, notification response, and badge count forwarding APIs.
- Adds the iOS-only `NotificationsManualIntegration` public API:
  - `IsEnabled` and `IsOneSignalNotification`
  - `DidRegisterForRemoteNotifications`
  - `DidFailToRegisterForRemoteNotifications`
  - `DidReceiveRemoteNotification`
  - `TryHandleWillPresentNotification`
  - `TryHandleNotificationResponse`
  - `SetBadgeCount`
- Gives OneSignal and non-OneSignal callbacks explicit routing with exact-once foreground and click completion ownership.
- Updates the local-notification example to disable swizzling, coordinate OneSignal and plugin delegate callbacks, and forward AppDelegate callbacks.
- Adds an in-app OneSignal test notification action targeting the current push subscription.
- Does not change default behavior; consumers must opt in with `OneSignal_disable_swizzling` and retain ownership of the notification delegate.

# Testing
## Unit testing
No unit tests were added because these APIs bridge UIKit/UserNotifications callbacks into the packaged native iOS framework and require native runtime behavior. The binding, AOT compilation, and callback paths were exercised directly.

## Manual testing
From `examples/plugin-local-notif`, I ran:

```sh
./run-ios.sh
```

I requested both OneSignal notification permission and local notification permission, then verified:

1. Displaying a local notification.
2. Clicking a local notification while the app was backgrounded.
3. Displaying a OneSignal notification using the in-app test action.
4. Clicking a OneSignal notification while the app was backgrounded.

All four paths completed without a managed registrar crash. The OneSignal `WillDisplay` and `Clicked` listeners also fired for their respective notification paths.

Additional verification:
- Built iOS Debug for `iossimulator-arm64` with zero warnings.
- Built and launched iOS Release/AOT for `iossimulator-arm64` with zero warnings.
- Confirmed the packaged Info.plist disables swizzling.
- Confirmed APNs token registration reaches OneSignal without a managed registrar crash.
- Confirmed OneSignal foreground `WillDisplay`, banner presentation, and a single Apple completion response.
- Built the Android example in Debug with zero warnings.
- Ran `csharpier check .` and `git diff --check`.
- Silent/background delivery still requires final physical-device validation because simulator delivery was inconclusive.

# Affected code checklist
   - [x] Notifications
      - [x] Display
      - [x] Open
      - [x] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [x] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on a simulator; physical-device background delivery remains noted above

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item


