### PR TITLE
fix: [SDK-4900] expose Android notification SetExtender

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Formatting
+
+Before creating a commit or pull request, run `csharpier format .` from the repository root. Include any resulting formatting changes in the commit.

--- a/OneSignalSDK.DotNet.Android.Core.Binding/OneSignalSDK.DotNet.Android.Core.Binding.csproj
+++ b/OneSignalSDK.DotNet.Android.Core.Binding/OneSignalSDK.DotNet.Android.Core.Binding.csproj
@@ -51,6 +51,7 @@
     <LibraryProjectZip Include="Jars\core-release.aar" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.12.0.1" />
     <PackageReference Include="Xamarin.Kotlin.StdLib.Jdk8" Version="1.9.23.3" />
   </ItemGroup>
 </Project>

--- a/OneSignalSDK.DotNet.nuspec
+++ b/OneSignalSDK.DotNet.nuspec
@@ -28,6 +28,7 @@
                 <dependency id="Xamarin.KotlinX.Serialization.Json" version="1.7.3.5" />
 
                 <dependency id="Xamarin.AndroidX.CardView" version="1.0.0.16" />
+                <dependency id="Xamarin.AndroidX.Core" version="1.12.0.1" />
                 <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.14" />
                 <dependency id="Xamarin.AndroidX.Browser" version="1.4.0.2" />
                 <dependency id="Xamarin.AndroidX.AppCompat" version="1.4.2.1" />

--- a/examples/android-service-ext/.env.example
+++ b/examples/android-service-ext/.env.example
@@ -1,0 +1,1 @@
+ONESIGNAL_APP_ID=your-onesignal-app-id

--- a/examples/android-service-ext/DotEnv.cs
+++ b/examples/android-service-ext/DotEnv.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+
+namespace OneSignalAndroidServiceExtension;
+
+internal static class DotEnv
+{
+    public static string Get(string key)
+    {
+        using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("appenv");
+        if (stream is null)
+            return "";
+
+        using var reader = new StreamReader(stream);
+        while (reader.ReadLine() is { } line)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith('#'))
+                continue;
+
+            var separator = trimmed.IndexOf('=');
+            if (separator < 1 || trimmed[..separator].Trim() != key)
+                continue;
+
+            return trimmed[(separator + 1)..].Trim().Trim('"', '\'');
+        }
+
+        return "";
+    }
+}

--- a/examples/android-service-ext/MainActivity.cs
+++ b/examples/android-service-ext/MainActivity.cs
@@ -4,6 +4,7 @@ using Android.OS;
 using Android.Views;
 using Android.Widget;
 using OneSignalSDK.DotNet;
+using OneSignalSDK.DotNet.Core.User.Subscriptions;
 
 namespace OneSignalAndroidServiceExtension;
 
@@ -14,29 +15,55 @@ namespace OneSignalAndroidServiceExtension;
 )]
 public sealed class MainActivity : Activity
 {
+    private TextView? _message;
+
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
 
         var appId = DotEnv.Get("ONESIGNAL_APP_ID");
         var isConfigured = Guid.TryParse(appId, out _);
-        var message = new TextView(this)
+        _message = new TextView(this)
         {
             Gravity = GravityFlags.Center,
             Text = isConfigured
-                ? "Send a push notification to test the blue accent color."
+                ? "Push ID: registering..."
                 : "Set ONESIGNAL_APP_ID in .env, then run the app again.",
             TextSize = 18,
         };
-        message.SetBackgroundColor(Color.White);
-        message.SetTextColor(Color.Black);
-        message.SetPadding(48, 48, 48, 48);
-        SetContentView(message);
+        _message.SetBackgroundColor(Color.White);
+        _message.SetTextColor(Color.Black);
+        _message.SetPadding(48, 48, 48, 48);
+        SetContentView(_message);
 
         if (!isConfigured)
             return;
 
         OneSignal.Initialize(appId);
+        OneSignal.User.PushSubscription.Changed += OnPushSubscriptionChanged;
+        RefreshPushId();
         _ = OneSignal.Notifications.RequestPermissionAsync(false);
+    }
+
+    protected override void OnDestroy()
+    {
+        OneSignal.User.PushSubscription.Changed -= OnPushSubscriptionChanged;
+        base.OnDestroy();
+    }
+
+    private void OnPushSubscriptionChanged(
+        object? sender,
+        PushSubscriptionChangedEventArgs args
+    )
+    {
+        RunOnUiThread(RefreshPushId);
+    }
+
+    private void RefreshPushId()
+    {
+        var pushId = OneSignal.User.PushSubscription.Id;
+        _message!.Text =
+            $"Push ID: {pushId ?? "registering..."}\n\n"
+            + "Send a push notification to test the blue accent color.";
     }
 }

--- a/examples/android-service-ext/MainActivity.cs
+++ b/examples/android-service-ext/MainActivity.cs
@@ -8,11 +8,7 @@ using OneSignalSDK.DotNet.Core.User.Subscriptions;
 
 namespace OneSignalAndroidServiceExtension;
 
-[Activity(
-    Label = "OneSignal Service Extension",
-    MainLauncher = true,
-    Exported = true
-)]
+[Activity(Label = "OneSignal Service Extension", MainLauncher = true, Exported = true)]
 public sealed class MainActivity : Activity
 {
     private TextView? _message;
@@ -51,10 +47,7 @@ public sealed class MainActivity : Activity
         base.OnDestroy();
     }
 
-    private void OnPushSubscriptionChanged(
-        object? sender,
-        PushSubscriptionChangedEventArgs args
-    )
+    private void OnPushSubscriptionChanged(object? sender, PushSubscriptionChangedEventArgs args)
     {
         RunOnUiThread(RefreshPushId);
     }

--- a/examples/android-service-ext/MainActivity.cs
+++ b/examples/android-service-ext/MainActivity.cs
@@ -14,19 +14,18 @@ namespace OneSignalAndroidServiceExtension;
 )]
 public sealed class MainActivity : Activity
 {
-    private const string OneSignalAppId = "YOUR-ONESIGNAL-APP-ID";
-
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
 
-        var isConfigured = OneSignalAppId != "YOUR-ONESIGNAL-APP-ID";
+        var appId = DotEnv.Get("ONESIGNAL_APP_ID");
+        var isConfigured = Guid.TryParse(appId, out _);
         var message = new TextView(this)
         {
             Gravity = GravityFlags.Center,
             Text = isConfigured
                 ? "Send a push notification to test the blue accent color."
-                : "Set OneSignalAppId in MainActivity.cs, then run the app again.",
+                : "Set ONESIGNAL_APP_ID in .env, then run the app again.",
             TextSize = 18,
         };
         message.SetBackgroundColor(Color.White);
@@ -37,7 +36,7 @@ public sealed class MainActivity : Activity
         if (!isConfigured)
             return;
 
-        OneSignal.Initialize(OneSignalAppId);
+        OneSignal.Initialize(appId);
         _ = OneSignal.Notifications.RequestPermissionAsync(false);
     }
 }

--- a/examples/android-service-ext/MainActivity.cs
+++ b/examples/android-service-ext/MainActivity.cs
@@ -12,8 +12,9 @@ namespace OneSignalAndroidServiceExtension;
 public sealed class MainActivity : Activity
 {
     private TextView? _message;
+    private bool _isSubscribed;
 
-    protected override void OnCreate(Bundle? savedInstanceState)
+    protected override async void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
 
@@ -37,13 +38,30 @@ public sealed class MainActivity : Activity
 
         OneSignal.Initialize(appId);
         OneSignal.User.PushSubscription.Changed += OnPushSubscriptionChanged;
+        _isSubscribed = true;
         RefreshPushId();
-        _ = OneSignal.Notifications.RequestPermissionAsync(false);
+
+        try
+        {
+            await OneSignal.Notifications.RequestPermissionAsync(false);
+        }
+        catch (Exception exception)
+        {
+            Toast
+                .MakeText(
+                    this,
+                    $"Notification permission request failed: {exception.Message}",
+                    ToastLength.Long
+                )
+                ?.Show();
+        }
     }
 
     protected override void OnDestroy()
     {
-        OneSignal.User.PushSubscription.Changed -= OnPushSubscriptionChanged;
+        if (_isSubscribed)
+            OneSignal.User.PushSubscription.Changed -= OnPushSubscriptionChanged;
+
         base.OnDestroy();
     }
 

--- a/examples/android-service-ext/MainActivity.cs
+++ b/examples/android-service-ext/MainActivity.cs
@@ -1,0 +1,43 @@
+using Android.App;
+using Android.Graphics;
+using Android.OS;
+using Android.Views;
+using Android.Widget;
+using OneSignalSDK.DotNet;
+
+namespace OneSignalAndroidServiceExtension;
+
+[Activity(
+    Label = "OneSignal Service Extension",
+    MainLauncher = true,
+    Exported = true
+)]
+public sealed class MainActivity : Activity
+{
+    private const string OneSignalAppId = "YOUR-ONESIGNAL-APP-ID";
+
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        var isConfigured = OneSignalAppId != "YOUR-ONESIGNAL-APP-ID";
+        var message = new TextView(this)
+        {
+            Gravity = GravityFlags.Center,
+            Text = isConfigured
+                ? "Send a push notification to test the blue accent color."
+                : "Set OneSignalAppId in MainActivity.cs, then run the app again.",
+            TextSize = 18,
+        };
+        message.SetBackgroundColor(Color.White);
+        message.SetTextColor(Color.Black);
+        message.SetPadding(48, 48, 48, 48);
+        SetContentView(message);
+
+        if (!isConfigured)
+            return;
+
+        OneSignal.Initialize(OneSignalAppId);
+        _ = OneSignal.Notifications.RequestPermissionAsync(false);
+    }
+}

--- a/examples/android-service-ext/NotificationServiceExtension.cs
+++ b/examples/android-service-ext/NotificationServiceExtension.cs
@@ -5,9 +5,7 @@ using Com.OneSignal.Android.Notifications;
 namespace OneSignalAndroidServiceExtension;
 
 [Register("com/onesignal/example/NotificationServiceExtension")]
-public sealed class NotificationServiceExtension
-    : Java.Lang.Object,
-        INotificationServiceExtension
+public sealed class NotificationServiceExtension : Java.Lang.Object, INotificationServiceExtension
 {
     public void OnNotificationReceived(INotificationReceivedEvent notificationEvent)
     {

--- a/examples/android-service-ext/NotificationServiceExtension.cs
+++ b/examples/android-service-ext/NotificationServiceExtension.cs
@@ -1,0 +1,24 @@
+using Android.Runtime;
+using AndroidX.Core.App;
+using Com.OneSignal.Android.Notifications;
+
+namespace OneSignalAndroidServiceExtension;
+
+[Register("com/onesignal/example/NotificationServiceExtension")]
+public sealed class NotificationServiceExtension
+    : Java.Lang.Object,
+        INotificationServiceExtension
+{
+    public void OnNotificationReceived(INotificationReceivedEvent notificationEvent)
+    {
+        notificationEvent.Notification.SetExtender(new NotificationExtender());
+    }
+}
+
+public sealed class NotificationExtender : Java.Lang.Object, NotificationCompat.IExtender
+{
+    public NotificationCompat.Builder Extend(NotificationCompat.Builder builder)
+    {
+        return builder.SetColor(unchecked((int)0xFF0066FF));
+    }
+}

--- a/examples/android-service-ext/NotificationServiceExtension.cs
+++ b/examples/android-service-ext/NotificationServiceExtension.cs
@@ -19,6 +19,8 @@ public sealed class NotificationExtender : Java.Lang.Object, NotificationCompat.
 {
     public NotificationCompat.Builder Extend(NotificationCompat.Builder builder)
     {
-        return builder.SetColor(unchecked((int)0xFF0066FF));
+        return builder
+            .SetColor(unchecked((int)0xFF0066FF))
+            .SetContentTitle(new Java.Lang.String("[Extended] Test"));
     }
 }

--- a/examples/android-service-ext/Properties/AndroidManifest.xml
+++ b/examples/android-service-ext/Properties/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <meta-data
+      android:name="com.onesignal.NotificationServiceExtension"
+      android:value="com.onesignal.example.NotificationServiceExtension"
+    />
+  </application>
+</manifest>

--- a/examples/android-service-ext/README.md
+++ b/examples/android-service-ext/README.md
@@ -2,7 +2,17 @@
 
 This Android app changes the notification accent color before OneSignal displays it.
 
-Replace `YOUR-ONESIGNAL-APP-ID` in `MainActivity.cs`, start an emulator or connect a device, then run:
+Create `.env` and set your OneSignal App ID:
+
+```shell
+cp examples/android-service-ext/.env.example examples/android-service-ext/.env
+```
+
+```dotenv
+ONESIGNAL_APP_ID=your-onesignal-app-id
+```
+
+Start an emulator or connect a device, then run:
 
 ```shell
 ./examples/android-service-ext/run-android.sh

--- a/examples/android-service-ext/README.md
+++ b/examples/android-service-ext/README.md
@@ -1,0 +1,29 @@
+# Android notification service extension
+
+This Android app changes the notification accent color before OneSignal displays it.
+
+Replace `YOUR-ONESIGNAL-APP-ID` in `MainActivity.cs`, start an emulator or connect a device, then run:
+
+```shell
+./examples/android-service-ext/run-android.sh
+```
+
+Copy `NotificationServiceExtension.cs` into the Android platform directory of your .NET MAUI app, then add the `<meta-data>` entry from `Properties/AndroidManifest.xml` inside your app's `<application>` element.
+
+The JNI class registered by `[Register]` uses slash separators; the same class in the manifest uses dot separators. Keep both names in sync.
+
+To suppress a notification permanently, call:
+
+```csharp
+notificationEvent.PreventDefault(true);
+```
+
+To delay display while doing asynchronous work, call `PreventDefault()`, then call `notificationEvent.Notification.Display()` within approximately 30 seconds.
+
+The sample references the SDK source project for local development. Apps consuming the released SDK should use the `OneSignalSDK.DotNet` NuGet package instead.
+
+Build the sample with:
+
+```shell
+dotnet build examples/android-service-ext/android-service-ext.csproj
+```

--- a/examples/android-service-ext/android-service-ext.csproj
+++ b/examples/android-service-ext/android-service-ext.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include=".env" Condition="Exists('.env')" LogicalName="appenv" />
     <ProjectReference Include="..\..\OneSignalSDK.DotNet\OneSignalSDK.DotNet.csproj" />
   </ItemGroup>
 </Project>

--- a/examples/android-service-ext/android-service-ext.csproj
+++ b/examples/android-service-ext/android-service-ext.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0-android</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>OneSignalAndroidServiceExtension</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <ApplicationTitle>OneSignal Android Service Extension</ApplicationTitle>
+    <ApplicationId>com.onesignal.example.serviceextension</ApplicationId>
+    <ApplicationVersion>1</ApplicationVersion>
+    <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
+    <SupportedOSPlatformVersion>26</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\OneSignalSDK.DotNet\OneSignalSDK.DotNet.csproj" />
+  </ItemGroup>
+</Project>

--- a/examples/android-service-ext/run-android.sh
+++ b/examples/android-service-ext/run-android.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/../run-android.sh" "$SCRIPT_DIR/android-service-ext.csproj"


### PR DESCRIPTION
# Description

## One Line Summary

Expose Android notification extenders in the .NET binding and add a runnable service-extension example.

## Details

### Motivation

The native Android SDK exposes `IMutableNotification.setExtender`, but the .NET binding generator omitted it because `NotificationCompat.Extender` could not be resolved. This prevented .NET apps from customizing notifications through an Android notification service extension. Addresses OneSignal/OneSignal-DotNet-SDK#92.

The duplicate-delivery and deferred `PreventDefault` timeout behavior also discussed in #92 is not changed by this PR. Current bundled Android SDKs expose `PreventDefault(true)` to permanently discard a notification; that existing behavior was validated while testing this change.

### Scope

* Add the AndroidX Core dependency to the binding project and published NuGet dependency list so `SetExtender(IExtender)` is generated and consumable.
* Add a runnable `examples/android-service-ext` app showing stable JNI registration, manifest configuration, notification customization, push subscription display, `.env` setup, permission error handling, and device launch tooling.
* No changes to the native OneSignal binaries, `PreventDefault` behavior, or cross-platform notification API.

# Testing

## Unit testing

No unit tests were added because the API surface is generated from the native AAR. The runnable sample provides compile-time coverage for the generated `SetExtender` method.

## Manual testing

* Built the Android SDK and service-extension sample in Release with 0 warnings and 0 errors.
* Removed the AndroidX Core dependency and performed a clean rebuild; the sample failed with the expected missing `SetExtender` compiler error. Restored the dependency and confirmed the build passes.
* Ran the sample on an Android emulator and received notifications in foreground/background flows.
* Confirmed the extender changes the title to `[Extended] Test` and applies the blue accent while preserving rich media and actions.
* Confirmed `PreventDefault(true)` suppresses display without restoration or the 30-second timeout; generation and receive-receipt workers completed successfully.

# Affected code checklist

- [X] Notifications
  - [X] Display
  - [ ] Open
  - [X] Push Processing
  - [ ] Confirm Deliveries
- [ ] Outcomes
- [ ] Sessions
- [ ] In-App Messaging
- [ ] REST API requests
- [X] Public API changes

# Checklist

## Overview

- [X] I have filled out all **REQUIRED** sections above
- [X] PR does one thing
- [X] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing

- [X] I have included test coverage for these changes, or explained why they are not needed
- [X] All automated tests pass, or I explained why that is not possible
- [X] I have personally tested this on my device, or explained why that is not possible

## Final pass

- [X] Code is as readable as possible.
- [X] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)