### PR TITLE
fix: [SDK-5087] include Android feature flags dependency

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,6 +71,13 @@ jobs:
       - name: Pack
         run: dotnet pack OneSignalSDK.DotNet/OneSignalSDK.DotNet.csproj --no-build -c Release /p:NuspecFile=../OneSignalSDK.DotNet.nuspec -o ./artifacts
 
+      - name: Verify Android feature flags dependency
+        run: |
+          PACKAGE=$(ls artifacts/*.nupkg)
+          unzip -p "$PACKAGE" lib/net10.0-android21.0/kmp-android-release.aar > "$RUNNER_TEMP/kmp-android-release.aar"
+          unzip -p "$RUNNER_TEMP/kmp-android-release.aar" classes.jar > "$RUNNER_TEMP/kmp-android-classes.jar"
+          jar tf "$RUNNER_TEMP/kmp-android-classes.jar" | grep -q '^com/onesignal/features/FeatureFlag.class$'
+
       - name: Publish to NuGet
         run: dotnet nuget push ./artifacts/*.nupkg --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
 

--- a/OneSignalSDK.DotNet.nuspec
+++ b/OneSignalSDK.DotNet.nuspec
@@ -77,6 +77,7 @@
         <file src="OneSignalSDK.DotNet\bin\Release\net10.0-android\OneSignalSDK.DotNet.Android.Notifications.Binding.pdb" target="lib\net10.0-android21.0" />
 
         <file src="OneSignalSDK.DotNet\bin\Release\net10.0-android\core-release.aar" target="lib\net10.0-android21.0" />
+        <file src="OneSignalSDK.DotNet\bin\Release\net10.0-android\kmp-android-release.aar" target="lib\net10.0-android21.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net10.0-android\in-app-messages-release.aar" target="lib\net10.0-android21.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net10.0-android\location-release.aar" target="lib\net10.0-android21.0" />
         <file src="OneSignalSDK.DotNet\bin\Release\net10.0-android\notifications-release.aar" target="lib\net10.0-android21.0" />


### PR DESCRIPTION
# Description
## One Line Summary
Includes the native Android KMP feature flags dependency in the published NuGet package.

## Details
### Motivation
OneSignalSDK.DotNet 6.2.4 crashes during Android startup because native Android SDK 5.9.9 moved `FeatureFlag` into `kmp-android-release.aar`, but that AAR was omitted from the NuGet package.

### Scope
Adds the KMP AAR to Android NuGet packaging and validates that the release artifact contains `FeatureFlag.class`. There are no public API changes.

### Other
A patch release is required after this PR merges because 6.2.4 is already published.

# Testing
## Unit testing
The release workflow now checks the packed KMP AAR for `com/onesignal/features/FeatureFlag.class` before publishing.

## Manual testing
- Built the SDK in Release configuration.
- Packed the NuGet artifact and verified the KMP AAR and `FeatureFlag.class` are present.
- Verified a clean Android consumer build includes `FeatureFlag` in the final APK.
- Ran `csharpier check .` successfully.
- Device testing was not performed because the regression is deterministic at the package-content boundary.

# Affected code checklist
   - [ ] Notifications
      - [ ] Display
      - [ ] Open
      - [ ] Push Processing
      - [ ] Confirm Deliveries
   - [ ] Outcomes
   - [ ] Sessions
   - [ ] In-App Messaging
   - [ ] REST API requests
   - [ ] Public API changes

# Checklist
## Overview
   - [x] I have filled out all **REQUIRED** sections above
   - [x] PR does one thing
   - [x] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [x] I have included test coverage for these changes, or explained why they are not needed
   - [x] All automated tests pass, or I explained why that is not possible
   - [x] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [x] Code is as readable as possible.
   - [x] I have reviewed this PR myself, ensuring it meets each checklist item

Made with [Cursor](https://cursor.com)