### PR TITLE
fix: align NSE binding with OneSignal iOS 5.6.0

### DIFF
--- a/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
+++ b/OneSignalSDK.DotNet.iOS.Binding/ApiDefinitions.cs
@@ -985,14 +985,6 @@ namespace Com.OneSignal.iOS
         //[Verify(MethodToProperty)]
         OSSession Session { get; }
 
-        // +(UNMutableNotificationContent *)didReceiveNotificationExtensionRequest:(UNNotificationRequest * _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent * _Nullable)replacementContent __attribute__((deprecated("Please use didReceiveNotificationExtensionRequest:withMutableNotificationContent:withContentHandler: instead.")));
-        [Static]
-        [Export("didReceiveNotificationExtensionRequest:withMutableNotificationContent:")]
-        UNMutableNotificationContent DidReceiveNotificationExtensionRequest(
-            UNNotificationRequest request,
-            [NullAllowed] UNMutableNotificationContent replacementContent
-        );
-
         // +(UNMutableNotificationContent *)didReceiveNotificationExtensionRequest:(UNNotificationRequest * _Nonnull)request withMutableNotificationContent:(UNMutableNotificationContent * _Nullable)replacementContent withContentHandler:(void (^)(UNNotificationContent * _Nonnull))contentHandler;
         [Static]
         [Export(


### PR DESCRIPTION
# Description
## One Line Summary
Remove the Notification Service Extension binding deleted by OneSignal iOS 5.6.0.

## Details
### Motivation
The release bundles OneSignal iOS 5.6.0, which no longer exposes the deprecated two-argument notification extension selector.

### Scope
Removes only the stale generated binding. The supported content-handler overload remains unchanged.

# Testing
## Unit testing
No tests were added because this aligns generated binding metadata with the bundled native framework.

## Manual testing
- `dotnet build OneSignalSDK.DotNet.iOS.Binding/OneSignalSDK.DotNet.iOS.Binding.csproj`

# Affected code checklist
- [x] Notifications
  - [x] Push Processing
- [x] Public API changes

# Checklist
## Overview
- [x] I have filled out all **REQUIRED** sections above
- [x] PR does one thing
- [x] Any Public API changes are explained and conform to the native API

## Testing
- [x] Test coverage is added or explained
- [x] All applicable automated checks pass
- [x] Device testing is not applicable to generated binding cleanup

## Final pass
- [x] Code is as readable as possible
- [x] I reviewed this PR
